### PR TITLE
[Feat] Enhanced MSA Scripts

### DIFF
--- a/scripts/msa/step1-get_prot_seq.py
+++ b/scripts/msa/step1-get_prot_seq.py
@@ -31,6 +31,7 @@ def get_seqs(mmcif_file):
 
     entity_poly = mmcif_parser.get_category_table("entity_poly")
     if entity_poly is None:
+        pdb_id = mmcif_file.name.split(".")[0]
         return pdb_id, None
     entity_poly["mmcif_seq_old"] = entity_poly.pdbx_seq_one_letter_code_can.str.replace(
         "\n", ""

--- a/scripts/msa/step1-get_prot_seq.py
+++ b/scripts/msa/step1-get_prot_seq.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import biotite.structure as struc
@@ -30,7 +31,6 @@ def get_seqs(mmcif_file):
 
     entity_poly = mmcif_parser.get_category_table("entity_poly")
     if entity_poly is None:
-        pdb_id = mmcif_file.name.split(".")[0]
         return pdb_id, None
     entity_poly["mmcif_seq_old"] = entity_poly.pdbx_seq_one_letter_code_can.str.replace(
         "\n", ""
@@ -57,8 +57,15 @@ def get_seqs(mmcif_file):
     if "pdbx_audit_revision_history" in mmcif_parser.cif.block:
         history = mmcif_parser.cif.block["pdbx_audit_revision_history"]
         info_df["release_date"] = history["revision_date"].as_array()[0]
+    else:
+        # Handle non-official mmcif file which transform from pdb file
+        info_df["release_date"] = datetime.now().strftime("%Y-%m-%d")
 
-    info_df["release_date_retrace_obsolete"] = mmcif_parser.release_date
+    if mmcif_parser.release_date:
+        info_df["release_date_retrace_obsolete"] = mmcif_parser.release_date
+    else:   
+        # Handle non-official mmcif file which transform from pdb file
+        info_df["release_date_retrace_obsolete"] = datetime.now().strftime("%Y-%m-%d")
 
     entity_poly_seq = mmcif_parser.get_category_table("entity_poly_seq")
 
@@ -189,8 +196,14 @@ def mapping_seqs_to_integer_identifiers(
 
 
 if __name__ == "__main__":
-    # It's a demo here
-    cif_dir = Path("./scripts/msa/data/mmcif")
+    import argparse
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cif_dir", type=str, default="./scripts/msa/data/mmcif")
+    parser.add_argument("--out_dir", type=str, default="./scripts/msa/data/pdb_seqs")
+    args = parser.parse_args()
+    
+    cif_dir = Path(args.cif_dir)
     cif_files = [x for x in cif_dir.iterdir() if x.is_file()]
 
     info_dfs = []
@@ -208,7 +221,7 @@ if __name__ == "__main__":
     out_df = pd.concat(info_dfs)
     out_df = out_df.sort_values(["pdb_id", "entity_id"])
 
-    out_dir = Path("./scripts/msa/data/pdb_seqs")
+    out_dir = Path(args.out_dir)
     if not out_dir.exists():
         out_dir.mkdir(parents=True)
     # 1. extract pdb sequence info

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -422,6 +422,6 @@ if __name__ == "__main__":
     )
 
     # Release all shared dictionaries if necessary
-    if args.use_shared_memory:
+    if args.shared_memory:
         for dict_id in get_shared_dict_ids():
             release_shared_dict(dict_id)

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -17,7 +17,6 @@ from os.path import join as opjoin
 from typing import Dict, List, Tuple, Optional, Union, Any
 import concurrent.futures
 import multiprocessing
-import time
 import math
 
 from tqdm import tqdm

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -243,9 +243,9 @@ def read_m8(
         print(f"Using sequential processing for {file_size/(1024*1024):.1f} MB file")
         uniref_to_ncbi_taxid = {}
         
-        # Use line-by-line processing which is more memory efficient
-        with open(m8_file, "r") as f:
-            for line in tqdm(f, desc="Reading m8 file", unit="lines"):
+        # Original single-threaded line-by-line processing
+        with open(m8_file, "r") as infile:
+            for line in tqdm(infile, desc="Reading m8 file", unit="lines"):
                 line_list = line.rstrip().split("\t")
                 hit_name = line_list[1]
                 ncbi_taxid = line_list[2]

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -121,10 +121,9 @@ def process_block_binary(block_info):
                     try:
                         line_str = full_line.decode('utf-8')
                         line_list = line_str.split('\t')
-                        if len(line_list) >= 3:
-                            hit_name = line_list[1]
-                            ncbi_taxid = line_list[2]
-                            local_dict[hit_name] = ncbi_taxid
+                        hit_name = line_list[1]
+                        ncbi_taxid = line_list[2]
+                        local_dict[hit_name] = ncbi_taxid
                     except Exception:
                         # Skip problematic lines
                         continue

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -13,20 +13,55 @@
 # limitations under the License.
 
 import os
+import mmap
+import psutil
 from os.path import join as opjoin
-from typing import Dict, List
+from typing import Dict, List, Tuple, Optional, Union, Any
+import concurrent.futures
+import multiprocessing
+import time
+import math
 
 from tqdm import tqdm
+from utils import (
+    convert_to_shared_dict,  # To create new shared dictionaries
+    release_shared_dict,     # To manually release dictionaries
+    get_shared_dict_ids      # To list available dictionaries
+)
 
 
-def read_a3m(a3m_file: str) -> tuple[List[str], List[str]]:
+def get_available_memory():
+    """Get available system memory in bytes."""
+    return psutil.virtual_memory().available
+
+
+def estimate_memory_needs(file_size):
+    """Roughly estimate memory needs for processing.
+    
+    Args:
+        file_size (int): Size of the file in bytes
+        
+    Returns:
+        int: Estimated memory in bytes needed for processing
+    """
+    # Estimate dictionary size: assume ~30% of file size for unique entries
+    # plus overhead for Python dictionary (which is roughly 2-4x the raw data size)
+    dict_estimate = file_size * 0.3 * 3
+    
+    # Some buffer for other operations
+    other_memory = 100 * 1024 * 1024  # 100MB
+    
+    return dict_estimate + other_memory
+
+
+def read_a3m(a3m_file: str) -> Tuple[List[str], List[str], int]:
     """read a3m file from output of mmseqs
 
     Args:
         a3m_file (str): the a3m file searched by mmseqs(colabfold search)
 
     Returns:
-        tuple[List[str], List[str]]: the header and seqs of a3m files
+        Tuple[List[str], List[str], int]: the header, seqs of a3m files, and uniref index
     """
     heads = []
     seqs = []
@@ -47,21 +82,163 @@ def read_a3m(a3m_file: str) -> tuple[List[str], List[str]]:
 
 
 def read_m8(m8_file: str) -> Dict[str, str]:
-    """the uniref_tax.m8 from output of mmseqs
-
+    """Read the uniref_tax.m8 file from output of mmseqs using block-wise memory mapping for efficiency.
+    
+    This implementation efficiently processes very large m8 files by:
+    1. Using block-wise memory mapping (mmap) to only load portions of the file at a time
+    2. Processing the file in multiple smaller chunks to minimize memory footprint
+    3. Monitoring dictionary growth to provide relevant warnings
+    
     Args:
         m8_file (str): the uniref_tax.m8 from output of mmseqs(colabfold search)
 
     Returns:
         Dict[str, str]: the dict mapping uniref hit_name to NCBI TaxID
     """
+    # Get file size to report progress
+    file_size = os.path.getsize(m8_file)
+    print(f"Reading m8 file ({file_size/(1024*1024):.1f} MB)...")
+    
+    # Check available memory and estimate needs for the final dictionary
+    available_memory = get_available_memory()
+    estimated_memory = estimate_memory_needs(file_size)
+    memory_ratio = estimated_memory / available_memory if available_memory > 0 else float('inf')
+    
+    if memory_ratio > 0.7:  # If using more than 70% of available memory
+        print("⚠️ Warning: This operation may require significant memory.")
+        if memory_ratio > 1.0:
+            print("⚠️ Consider using the --shared_memory option for large files.")
+    
+    # Create a regular dictionary for fast loading
     uniref_to_ncbi_taxid = {}
-    with open(m8_file, "r") as infile:
-        for line in infile:
-            line_list = line.replace("\n", "").split("\t")
-            hit_name = line_list[1]
-            ncbi_taxid = line_list[2]
-            uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
+    
+    line_count = 0
+    
+    # If the file is very small, don't use mmap (overhead not worth it)
+    if file_size < 10 * 1024 * 1024:  # less than 10MB
+        with open(m8_file, "r") as f:
+            for line in tqdm(f, desc="Reading m8 file", unit="lines"):
+                line_list = line.rstrip().split("\t")
+                if len(line_list) >= 3:
+                    hit_name = line_list[1]
+                    ncbi_taxid = line_list[2]
+                    uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
+                line_count += 1
+    else:
+        # For larger files, use block-wise mmap for memory efficiency
+        # Calculate block size - we'll use larger blocks (1GB) since we're only mapping one at a time
+        # This provides better performance while still keeping memory usage reasonable
+        block_size = 1024 * 1024 * 1024  # 1GB blocks
+        num_blocks = math.ceil(file_size / block_size)
+        
+        # Calculate an approximate number of lines for the progress bar
+        with open(m8_file, "r") as f:
+            # Sample first few lines to estimate average line length
+            sample_size = min(5000, file_size)
+            sample = f.read(sample_size)
+            line_sample_count = sample.count('\n')
+            if line_sample_count > 0:
+                avg_line_length = sample_size / line_sample_count
+                estimated_lines = int(file_size / avg_line_length)
+            else:
+                estimated_lines = 1000000  # Default estimate if we can't calculate
+        
+        # Use a single progress bar for all blocks
+        with tqdm(total=estimated_lines, desc="Reading m8 file") as pbar:
+            # Process file block by block
+            for block_num in range(num_blocks):
+                block_offset = block_num * block_size
+                block_length = min(block_size, file_size - block_offset)
+                
+                with open(m8_file, "r") as f:
+                    # Create a memory map for just this block
+                    mm = mmap.mmap(f.fileno(), length=block_length, offset=block_offset, access=mmap.ACCESS_READ)
+                    
+                    try:
+                        # Skip partial line at the beginning if not the first block
+                        if block_num > 0:
+                            # Find first newline to skip partial line
+                            first_newline = mm.find(b'\n')
+                            if first_newline != -1:
+                                mm.seek(first_newline + 1)
+                        
+                        # Process lines in this block
+                        block_line_count = 0
+                        partial_line = b''
+                        
+                        while True:
+                            # Read a larger chunk of data for more efficient processing
+                            # Increased from 1MB to 4MB chunks for better performance
+                            chunk = mm.read(min(4 * 1024 * 1024, mm.size() - mm.tell()))
+                            if not chunk:
+                                break
+                            
+                            # Combine with any partial line from previous chunk
+                            data = partial_line + chunk
+                            
+                            # Find the last newline in the chunk
+                            last_newline_pos = data.rfind(b'\n')
+                            
+                            if last_newline_pos == -1:
+                                # No newlines, store entire chunk as partial
+                                partial_line = data
+                                continue
+                            
+                            # Split the complete lines and save the partial for next iteration
+                            complete_data = data[:last_newline_pos+1]
+                            partial_line = data[last_newline_pos+1:]
+                            
+                            # Process the complete lines
+                            lines = complete_data.split(b'\n')
+                            for line in lines:
+                                if not line:  # Skip empty lines
+                                    continue
+                                    
+                                try:
+                                    line_str = line.decode('utf-8')
+                                    line_list = line_str.split('\t')
+                                    
+                                    # Process valid lines with at least 3 columns
+                                    if len(line_list) >= 3:
+                                        hit_name = line_list[1]
+                                        ncbi_taxid = line_list[2]
+                                        uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
+                                    
+                                    block_line_count += 1
+                                    line_count += 1
+                                    
+                                    # Update progress occasionally
+                                    if block_line_count % 1000 == 0:
+                                        pbar.update(1000)
+                                except Exception as _:
+                                    # Skip lines that can't be processed
+                                    continue
+                        
+                        # Handle any remaining partial line if we're in the last block
+                        if block_num == num_blocks - 1 and partial_line:
+                            try:
+                                line_str = partial_line.decode('utf-8')
+                                line_list = line_str.split('\t')
+                                
+                                if len(line_list) >= 3:
+                                    hit_name = line_list[1]
+                                    ncbi_taxid = line_list[2]
+                                    uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
+                                
+                                line_count += 1
+                            except Exception as _:
+                                pass
+                    
+                    finally:
+                        # Always close the memory map
+                        mm.close()
+                        
+                    # Update progress bar for this block
+                    if block_line_count % 1000 != 0:
+                        pbar.update(block_line_count % 1000)
+    
+    print(f"Processed {len(uniref_to_ncbi_taxid):,} unique entries")
+    
     return uniref_to_ncbi_taxid
 
 
@@ -69,16 +246,18 @@ def update_a3m(
     a3m_path: str,
     uniref_to_ncbi_taxid: Dict,
     save_root: str,
-) -> None:
+) -> str:
     """add NCBI TaxID to header if "UniRef" in header
 
     Args:
         a3m_path (str): the original a3m path returned by mmseqs(colabfold search)
         uniref_to_ncbi_taxid (Dict): the dict mapping uniref hit_name to NCBI TaxID
         save_root (str): the updated a3m
+        
+    Returns:
+        str: The path of the processed a3m file
     """
     heads, seqs, uniref_index = read_a3m(a3m_path)
-    print(uniref_index)
     fname = a3m_path.split("/")[-1]
     out_a3m_path = opjoin(save_root, fname)
     with open(out_a3m_path, "w") as ofile:
@@ -93,21 +272,156 @@ def update_a3m(
                 else:
                     head = head.replace(uniref_id, f"{uniref_id}_{ncbi_taxid}/")
             ofile.write(f"{head}{seq}")
+    return out_a3m_path
+
+
+def update_a3m_batch(batch_paths, uniref_to_ncbi_taxid, save_root):
+    """Process a batch of a3m files.
+    
+    Args:
+        batch_paths (List[str]): List of paths to a3m files to process
+        uniref_to_ncbi_taxid (Dict[str, str]): Dictionary mapping UniRef IDs to NCBI TaxIDs
+        save_root (str): Directory to save processed files
+        
+    Returns:
+        List[str]: List of processed file paths
+    """
+    results = []
+    for a3m_path in batch_paths:
+        result = update_a3m(
+            a3m_path=a3m_path,
+            uniref_to_ncbi_taxid=uniref_to_ncbi_taxid,
+            save_root=save_root
+        )
+        results.append(result)
+    return results
+
+
+def process_files(
+    a3m_paths: List[str],
+    uniref_to_ncbi_taxid: Union[Dict[str, str], Any],
+    output_msa_dir: str,
+    num_workers: Optional[int] = None,
+    batch_size: Optional[int] = None
+) -> None:
+    """Process multiple a3m files with optimized performance.
+    
+    This function uses a more efficient approach for multiprocessing by using batched 
+    processing to reduce the overhead of process creation and task management.
+    Works with both regular dictionaries and shared dictionaries.
+    
+    Args:
+        a3m_paths (List[str]): List of a3m file paths to process
+        uniref_to_ncbi_taxid (Union[Dict[str, str], Any]): 
+            Dictionary mapping UniRef IDs to NCBI TaxIDs, can be either a regular dict or a shared dict
+        output_msa_dir (str): Directory to save processed files
+        num_workers (int, optional): Number of worker processes. Defaults to None (uses CPU count).
+        batch_size (int, optional): Size of batches for processing. Defaults to None (auto-calculated).
+    """
+    if num_workers is None:
+        # Use a smaller number of workers to avoid excessive overhead
+        num_workers = max(1, min(multiprocessing.cpu_count() - 1, 16))
+    
+    total_files = len(a3m_paths)
+    
+    if batch_size is None:
+        # Calculate an optimal batch size based on number of files and workers
+        # Aim for each worker to get 2-5 batches for good load balancing
+        target_batches_per_worker = 3
+        batch_size = max(1, math.ceil(total_files / (num_workers * target_batches_per_worker)))
+    
+    # Create batches
+    batches = []
+    for i in range(0, len(a3m_paths), batch_size):
+        batch = a3m_paths[i:i + batch_size]
+        batches.append(batch)
+    
+    # Process in single-threaded mode if we have very few files or only one worker
+    if total_files < 10 or num_workers == 1:
+        with tqdm(total=total_files, desc="Processing a3m files") as pbar:
+            for a3m_path in a3m_paths:
+                update_a3m(
+                    a3m_path=a3m_path,
+                    uniref_to_ncbi_taxid=uniref_to_ncbi_taxid,
+                    save_root=output_msa_dir,
+                )
+                pbar.update(1)
+        return
+    
+    start_time = time.time()
+    
+    # Use ProcessPoolExecutor for parallel processing
+    with concurrent.futures.ProcessPoolExecutor(max_workers=num_workers) as executor:
+        # Submit batch tasks instead of individual files
+        futures = []
+        for batch in batches:
+            future = executor.submit(
+                update_a3m_batch, 
+                batch, 
+                uniref_to_ncbi_taxid, 
+                output_msa_dir
+            )
+            futures.append(future)
+        
+        # Track progress across all batches
+        completed_files = 0
+        with tqdm(total=total_files, desc="Processing a3m files") as pbar:
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    # Each result is a list of file paths processed in the batch
+                    result = future.result()
+                    batch_size = len(result)
+                    completed_files += batch_size
+                    pbar.update(batch_size)
+                except Exception as e:
+                    print(f"Error processing batch: {e}")
+                    # Estimate how many files might have been in this failed batch
+                    avg_batch_size = total_files / len(batches)
+                    pbar.update(int(avg_batch_size))
+    
+    end_time = time.time()
+    elapsed = end_time - start_time
+    print(f"Processing complete ({elapsed:.1f} seconds)")
 
 
 if __name__ == "__main__":
-    input_msa_dir = "./scripts/msa/data/mmcif_msa_initial"
+    import argparse
 
-    output_msa_dir = "./scripts/msa/data/mmcif_msa_with_taxid"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_msa_dir", type=str, default="./scripts/msa/data/mmcif_msa_initial")
+    parser.add_argument("--output_msa_dir", type=str, default="./scripts/msa/data/mmcif_msa_with_taxid")
+    parser.add_argument("--num_workers", type=int, default=None, 
+                        help="Number of worker processes. Defaults to auto.")
+    parser.add_argument("--batch_size", type=int, default=None,
+                        help="Number of files per batch. Defaults to auto.")
+    parser.add_argument("--shared_memory", action="store_true",
+                        help="Use shared memory for dictionary to reduce memory usage.")
+    args = parser.parse_args()
+    input_msa_dir = args.input_msa_dir
+    output_msa_dir = args.output_msa_dir
     os.makedirs(output_msa_dir, exist_ok=True)
 
     a3m_paths = os.listdir(input_msa_dir)
     a3m_paths = [opjoin(input_msa_dir, x) for x in a3m_paths if x.endswith(".a3m")]
     m8_file = f"{input_msa_dir}/uniref_tax.m8"
+    
+    # Read m8 file (always into a regular dictionary for performance)
     uniref_to_ncbi_taxid = read_m8(m8_file)
-    for a3m_path in tqdm(a3m_paths):
-        update_a3m(
-            a3m_path=a3m_path,
-            uniref_to_ncbi_taxid=uniref_to_ncbi_taxid,
-            save_root=output_msa_dir,
-        )
+    
+    if args.shared_memory:
+        # Use shared memory dictionary
+        uniref_to_ncbi_taxid = convert_to_shared_dict(uniref_to_ncbi_taxid)
+    
+    # Process the a3m files
+    process_files(
+        a3m_paths=a3m_paths,
+        uniref_to_ncbi_taxid=uniref_to_ncbi_taxid,
+        output_msa_dir=output_msa_dir,
+        num_workers=args.num_workers,
+        batch_size=args.batch_size
+    )
+
+    # Release all shared dictionaries if necessary
+    if args.use_shared_memory:
+        for dict_id in get_shared_dict_ids():
+            release_shared_dict(dict_id)

--- a/scripts/msa/step3-uniref_add_taxid.py
+++ b/scripts/msa/step3-uniref_add_taxid.py
@@ -247,10 +247,9 @@ def read_m8(
         with open(m8_file, "r") as f:
             for line in tqdm(f, desc="Reading m8 file", unit="lines"):
                 line_list = line.rstrip().split("\t")
-                if len(line_list) >= 3:
-                    hit_name = line_list[1]
-                    ncbi_taxid = line_list[2]
-                    uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
+                hit_name = line_list[1]
+                ncbi_taxid = line_list[2]
+                uniref_to_ncbi_taxid[hit_name] = ncbi_taxid
         
         print(f"Processed {len(uniref_to_ncbi_taxid):,} unique entries")
         return uniref_to_ncbi_taxid

--- a/scripts/msa/step4-split_msa_to_uniref_and_others.py
+++ b/scripts/msa/step4-split_msa_to_uniref_and_others.py
@@ -302,7 +302,7 @@ def process_files_batched(
         batch_size: Number of files to process in each batch
     """
     if batch_size is None:
-        batch_size = len(file_list) // num_workers
+        batch_size = max(1, len(file_list) // num_workers)
     
     # Split files into batches
     batches = chunk_list(file_list, batch_size)
@@ -371,7 +371,7 @@ def main():
                         help="Number of parallel workers to use (default: half of all CPU cores or 1)")
     parser.add_argument("--batch_size", type=int, default=None,
                         help="Number of files to process in each batch (default: adjusted automatically)")
-    parser.add_argument("--use_shared_memory", action="store_true",
+    parser.add_argument("--shared_memory", action="store_true",
                         help="Use shared memory for dictionaries to reduce memory usage")
     args = parser.parse_args()
 
@@ -384,7 +384,7 @@ def main():
     _, first_pdbid_to_seq, seq_to_pdb_index = load_mapping_data(
         args.seq_to_pdb_id, 
         args.seq_to_pdb_index,
-        use_shared_memory=args.use_shared_memory
+        use_shared_memory=args.shared_memory
     )
     print("Mapping data loaded successfully")
 
@@ -408,7 +408,7 @@ def main():
     )
     
     # Release all shared dictionaries if necessary
-    if args.use_shared_memory:
+    if args.shared_memory:
         for dict_id in get_shared_dict_ids():
             release_shared_dict(dict_id)
 

--- a/scripts/msa/step4-split_msa_to_uniref_and_others.py
+++ b/scripts/msa/step4-split_msa_to_uniref_and_others.py
@@ -14,19 +14,74 @@
 
 import json
 import os
+import concurrent.futures
+import multiprocessing
 from functools import partial
 from os.path import join as opjoin
-from typing import Callable, Tuple
+from typing import Callable, Dict, Tuple, List, Set, Any, Mapping, Union, Optional
+from tqdm import tqdm
+import time
+import fcntl  # For file locking
 
-with open("./scripts/msa/data/pdb_seqs/seq_to_pdb_id_entity_id.json", "r") as f:
-    seq_to_pdbid = json.load(f)
-first_pdbid_to_seq = {"_".join(v[0]): k for k, v in seq_to_pdbid.items()}
+from utils import (
+    convert_to_shared_dict,  # To create new shared dictionaries
+    release_shared_dict,     # To manually release dictionaries
+    get_shared_dict_ids      # To list available dictionaries
+)
 
-with open("./scripts/msa/data/pdb_seqs/seq_to_pdb_index.json", "r") as f:
-    seq_to_pdb_index = json.load(f)
+# Type alias for dictionary-like objects (regular dict or Manager.dict)
+DictLike = Union[Dict[str, Any], Mapping[str, Any]]
 
 
-def rematch(pdb_line: str) -> Tuple[str, str]:
+def load_mapping_data(seq_to_pdb_id_path: str, seq_to_pdb_index_path: str, use_shared_memory: bool = False) -> Tuple[Dict[str, Any], DictLike, DictLike]:
+    """
+    Load mapping data from JSON files.
+    
+    Args:
+        seq_to_pdb_id_path: Path to the seq_to_pdb_id_entity_id.json file
+        seq_to_pdb_index_path: Path to the seq_to_pdb_index.json file
+        use_shared_memory: Whether to use shared memory for dictionaries
+        
+    Returns:
+        Tuple containing (seq_to_pdbid, first_pdbid_to_seq, seq_to_pdb_index) dictionaries
+    """
+    # Load sequence to PDB ID mapping
+    with open(seq_to_pdb_id_path, "r") as f:
+        seq_to_pdbid = json.load(f)
+    
+    # Create reverse mapping for easy lookup
+    first_pdbid_to_seq_data = {"_".join(v[0]): k for k, v in seq_to_pdbid.items()}
+    
+    # Load sequence to PDB index mapping
+    with open(seq_to_pdb_index_path, "r") as f:
+        seq_to_pdb_index_data = json.load(f)
+    
+    # If using shared memory, convert the dictionaries to shared objects
+    if use_shared_memory:
+        # Create shared dictionaries
+        first_pdbid_to_seq = convert_to_shared_dict(first_pdbid_to_seq_data)
+        seq_to_pdb_index = convert_to_shared_dict(seq_to_pdb_index_data)
+        
+        print(f"Created shared memory dictionaries: {len(first_pdbid_to_seq)} PDB IDs, {len(seq_to_pdb_index)} index mappings")
+    else:
+        first_pdbid_to_seq = first_pdbid_to_seq_data
+        seq_to_pdb_index = seq_to_pdb_index_data
+        
+    return seq_to_pdbid, first_pdbid_to_seq, seq_to_pdb_index
+
+
+def rematch(pdb_line: str, first_pdbid_to_seq: DictLike, seq_to_pdb_index: DictLike) -> Tuple[str, str]:
+    """
+    Match a PDB line to its corresponding sequence and index.
+    
+    Args:
+        pdb_line: PDB header line
+        first_pdbid_to_seq: Dictionary mapping PDB IDs to sequences
+        seq_to_pdb_index: Dictionary mapping sequences to PDB indices
+        
+    Returns:
+        Tuple of (pdb_index, origin_query_seq)
+    """
     pdb_id = pdb_line[1:-1]
     origin_query_seq = first_pdbid_to_seq[pdb_id]
     pdb_index = seq_to_pdb_index[origin_query_seq]
@@ -38,14 +93,59 @@ def write_log(
     fname: str,
     log_root: str,
 ) -> None:
+    """
+    Write a log message to a file with proper file locking to handle concurrency.
+    
+    Args:
+        msg: Message to log
+        fname: File name associated with the log
+        log_root: Root directory for log files
+    """
     basename = fname.split(".")[0]
-    with open(opjoin(log_root, f"{basename}-{msg}"), "w") as f:
-        pass
+    log_path = opjoin(log_root, f"{basename}-{msg}")
+    
+    # Create a directory for lock files
+    lock_dir = opjoin(log_root, "locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    
+    # Use a separate lock file for each log file
+    lock_path = opjoin(lock_dir, f"{basename}-{msg}.lock")
+    
+    try:
+        # Open (or create) the lock file
+        with open(lock_path, 'w') as lock_file:
+            # Acquire an exclusive lock (blocking)
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            
+            # Now safely create the log file
+            with open(log_path, "w") as f:
+                f.write(msg)
+            
+            # The lock is automatically released when the file is closed
+    except Exception as e:
+        # If something goes wrong, log it but don't crash
+        print(f"Warning: Failed to write log for {fname}: {e}")
 
 
 def process_one_file(
-    fname: str, msa_root: str, save_root: str, logger: Callable
+    fname: str, 
+    msa_root: str, 
+    save_root: str, 
+    logger: Callable,
+    first_pdbid_to_seq: DictLike,
+    seq_to_pdb_index: DictLike
 ) -> None:
+    """
+    Process a single MSA file.
+    
+    Args:
+        fname: Filename of the MSA file to process
+        msa_root: Root directory containing MSA files
+        save_root: Root directory to save processed files
+        logger: Function to log events
+        first_pdbid_to_seq: Dictionary mapping PDB IDs to sequences
+        seq_to_pdb_index: Dictionary mapping sequences to PDB indices
+    """
     with open(file_path := opjoin(msa_root, fname), "r") as f:
         for i, line in enumerate(f):
             if i == 0:
@@ -57,7 +157,7 @@ def process_one_file(
                 query_line = line
                 break
 
-    save_fname, origin_query_seq = rematch(pdb_line)
+    save_fname, origin_query_seq = rematch(pdb_line, first_pdbid_to_seq, seq_to_pdb_index)
 
     os.makedirs(sub_dir_path := opjoin(save_root, f"{save_fname}"), exist_ok=True)
     uniref100_lines = [">query\n", f"{origin_query_seq}\n"]
@@ -95,18 +195,225 @@ def process_one_file(
             f.write(line)
 
 
-if __name__ == "__main__":
-    msa_root = "./scripts/msa/data/mmcif_msa_with_taxid"
-    save_root = "./scripts/msa/data/mmcif_msa"
+def process_file_batch(
+    file_batch: List[str], 
+    msa_root: str, 
+    save_root: str, 
+    log_root: str,
+    first_pdbid_to_seq: DictLike,
+    seq_to_pdb_index: DictLike
+) -> Set[str]:
+    """
+    Process a batch of MSA files.
+    
+    Args:
+        file_batch: List of filenames to process in this batch
+        msa_root: Root directory containing MSA files
+        save_root: Root directory to save processed files
+        log_root: Root directory for log files
+        first_pdbid_to_seq: Dictionary mapping PDB IDs to sequences
+        seq_to_pdb_index: Dictionary mapping sequences to PDB indices
+        
+    Returns:
+        Set of files that were processed successfully
+    """
+    # Create a logger for this batch
+    batch_logger = partial(write_log, log_root=log_root)
+    
+    # Track completed files
+    completed_files = set()
+    
+    # Process each file in the batch
+    for fname in file_batch:
+        try:
+            process_one_file(
+                fname=fname,
+                msa_root=msa_root,
+                save_root=save_root,
+                logger=batch_logger,
+                first_pdbid_to_seq=first_pdbid_to_seq,
+                seq_to_pdb_index=seq_to_pdb_index
+            )
+            completed_files.add(fname)
+        except Exception as e:
+            # Log any exceptions but continue processing the batch
+            basename = fname.split(".")[0]
+            error_path = opjoin(log_root, f"{basename}-exception")
+            lock_dir = opjoin(log_root, "locks")
+            lock_path = opjoin(lock_dir, f"{basename}-exception.lock")
+            
+            try:
+                # Ensure lock directory exists
+                os.makedirs(lock_dir, exist_ok=True)
+                
+                # Use file locking for the error log too
+                with open(lock_path, 'w') as lock_file:
+                    fcntl.flock(lock_file, fcntl.LOCK_EX)
+                    with open(error_path, "w") as f:
+                        f.write(str(e))
+                    # Lock is released when file is closed
+            except Exception as log_error:
+                # If locking fails, try direct write as fallback
+                try:
+                    with open(error_path, "w") as f:
+                        f.write(f"{str(e)}\nAdditional error during logging: {str(log_error)}")
+                except Exception:
+                    # Last resort - print to stdout
+                    print(f"Error processing {fname} and failed to log: {str(e)}")
+    
+    return completed_files
+
+
+def chunk_list(lst: List, chunk_size: int) -> List[List]:
+    """
+    Split a list into chunks of specified size.
+    
+    Args:
+        lst: List to split
+        chunk_size: Size of each chunk
+        
+    Returns:
+        List of chunked lists
+    """
+    return [lst[i:i + chunk_size] for i in range(0, len(lst), chunk_size)]
+
+
+def process_files_batched(
+    file_list: List[str], 
+    msa_root: str, 
+    save_root: str, 
+    log_root: str,
+    first_pdbid_to_seq: DictLike,
+    seq_to_pdb_index: DictLike,
+    num_workers: int,
+    batch_size: Optional[int],
+) -> None:
+    """
+    Process files in batches using parallel processing.
+    
+    Args:
+        file_list: List of files to process
+        msa_root: Root directory containing MSA files
+        save_root: Root directory to save processed files
+        log_root: Root directory for log files
+        first_pdbid_to_seq: Dictionary mapping PDB IDs to sequences (possibly shared)
+        seq_to_pdb_index: Dictionary mapping sequences to PDB indices (possibly shared)
+        num_workers: Number of parallel workers to use
+        batch_size: Number of files to process in each batch
+    """
+    if batch_size is None:
+        batch_size = len(file_list) // num_workers
+    
+    # Split files into batches
+    batches = chunk_list(file_list, batch_size)
+    print(f"Split {len(file_list)} files into {len(batches)} batches of size ~{batch_size}")
+    
+    # Create a partial function with fixed arguments
+    batch_processor = partial(
+        process_file_batch,
+        msa_root=msa_root,
+        save_root=save_root,
+        log_root=log_root,
+        first_pdbid_to_seq=first_pdbid_to_seq,
+        seq_to_pdb_index=seq_to_pdb_index
+    )
+    
+    # Track progress and timing
+    start_time = time.time()
+    total_processed = 0
+    
+    # Use ProcessPoolExecutor for parallel processing
+    with concurrent.futures.ProcessPoolExecutor(max_workers=num_workers) as executor:
+        # Process batches with progress tracking
+        with tqdm(total=len(file_list), desc="Processing MSA files") as pbar:
+            futures = []
+            
+            # Submit all batches to the executor
+            for batch in batches:
+                futures.append(executor.submit(batch_processor, batch))
+            
+            # Process results as they complete
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    # Get the set of completed files
+                    completed_files = future.result()
+                    batch_count = len(completed_files)
+                    total_processed += batch_count
+                    pbar.update(batch_count)
+                    
+                    # Calculate and display statistics
+                    elapsed = time.time() - start_time
+                    files_per_second = total_processed / elapsed if elapsed > 0 else 0
+                    pbar.set_postfix(
+                        {"processed": total_processed, "files/sec": f"{files_per_second:.2f}"}
+                    )
+                except Exception as e:
+                    print(f"Error processing batch: {e}")
+    
+    # Print final statistics
+    total_time = time.time() - start_time
+    print(f"Processed {total_processed} files in {total_time:.2f} seconds")
+    print(f"Average processing speed: {total_processed / total_time:.2f} files/second")
+
+
+def main():
+    """Main function to run the script with command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_msa_dir", type=str, default="./scripts/msa/data/mmcif_msa_with_taxid")
+    parser.add_argument("--output_msa_dir", type=str, default="./scripts/msa/data/mmcif_msa")
+    parser.add_argument("--seq_to_pdb_id", type=str, 
+                        default="./scripts/msa/data/pdb_seqs/seq_to_pdb_id_entity_id.json")
+    parser.add_argument("--seq_to_pdb_index", type=str, 
+                        default="./scripts/msa/data/pdb_seqs/seq_to_pdb_index.json")
+    parser.add_argument("--num_workers", type=int, default=multiprocessing.cpu_count(), 
+                        help="Number of parallel workers to use (default: half of all CPU cores or 1)")
+    parser.add_argument("--batch_size", type=int, default=None,
+                        help="Number of files to process in each batch (default: adjusted automatically)")
+    parser.add_argument("--use_shared_memory", action="store_true",
+                        help="Use shared memory for dictionaries to reduce memory usage")
+    args = parser.parse_args()
+
+    msa_root = args.input_msa_dir
+    save_root = args.output_msa_dir
     log_root = "./scripts/msa/data/mmcif_msa_log"
+    
+    # Load mapping data
+    print("Loading mapping data...")
+    _, first_pdbid_to_seq, seq_to_pdb_index = load_mapping_data(
+        args.seq_to_pdb_id, 
+        args.seq_to_pdb_index,
+        use_shared_memory=args.use_shared_memory
+    )
+    print("Mapping data loaded successfully")
 
     os.makedirs(log_root, exist_ok=True)
     os.makedirs(save_root, exist_ok=True)
 
     print("Loading file names...")
+    file_list = os.listdir(msa_root)
+    print(f"Found {len(file_list)} MSA files to process")
+    
+    # Process files in batches
+    process_files_batched(
+        file_list=file_list,
+        msa_root=msa_root,
+        save_root=save_root,
+        log_root=log_root,
+        first_pdbid_to_seq=first_pdbid_to_seq,
+        seq_to_pdb_index=seq_to_pdb_index,
+        num_workers=args.num_workers,
+        batch_size=args.batch_size
+    )
+    
+    # Release all shared dictionaries if necessary
+    if args.use_shared_memory:
+        for dict_id in get_shared_dict_ids():
+            release_shared_dict(dict_id)
 
-    logger = partial(write_log, log_root=log_root)
-    for fname in os.listdir(msa_root):
-        process_one_file(
-            fname=fname, msa_root=msa_root, save_root=save_root, logger=logger
-        )
+
+if __name__ == "__main__":
+    # Set start method to spawn to ensure compatibility with shared memory
+    multiprocessing.set_start_method('spawn', force=True)
+    main()

--- a/scripts/msa/utils.py
+++ b/scripts/msa/utils.py
@@ -1,0 +1,277 @@
+import pickle
+import atexit
+import sys
+import uuid
+from multiprocessing import shared_memory
+from typing import Dict, Any, List, Optional
+
+
+# Global dictionary to track all shared memory blocks
+_shared_memory_blocks = {}
+
+
+# Function to clean up shared memory resources on program exit
+def cleanup_shared_memory():
+    """Clean up all shared memory objects when the program exits."""
+    global _shared_memory_blocks
+    
+    if _shared_memory_blocks:
+        try:
+            # Close and unlink all shared memory blocks
+            for name, shm in list(_shared_memory_blocks.items()):
+                try:
+                    shm.close()
+                    shm.unlink()
+                    # No need to print anything during normal exit
+                except Exception as e:
+                    if not sys.stdout.closed:
+                        print(f"Error cleaning up shared memory '{name}': {e}")
+            
+            # Clear the dictionary
+            _shared_memory_blocks.clear()
+        except Exception as e:
+            if not sys.stdout.closed:
+                print(f"Error during shared memory cleanup: {e}")
+
+
+# Register the cleanup function to run on program exit
+atexit.register(cleanup_shared_memory)
+
+
+class SharedDict:
+    """A dictionary-like object that provides fast read access to shared memory data.
+    
+    This class provides dictionary-like access to shared memory with performance
+    approaching that of a local dictionary. On first access in each worker process,
+    the dictionary is loaded into local memory for maximum lookup performance while
+    still saving memory across the main process.
+    """
+    
+    def __init__(self, shared_dict_info, dict_id=None):
+        """Initialize with shared memory information.
+        
+        Args:
+            shared_dict_info (dict): Information about the shared memory block
+            dict_id (str, optional): Unique identifier for this shared dictionary
+        """
+        self.info = shared_dict_info
+        self.dict_id = dict_id
+        # Initialize with an empty dictionary to satisfy type checkers
+        self._dict = {}
+        self._shm = None
+        self._loaded = False
+    
+    def _load_dict(self):
+        """Load the dictionary from shared memory if not already loaded.
+        
+        This only happens once per process, making all subsequent lookups
+        as fast as a local dictionary.
+        """
+        if not self._loaded:
+            try:
+                # Access the shared memory block
+                shm = shared_memory.SharedMemory(name=self.info['name'])
+                # Deserialize the dictionary
+                data = bytes(shm.buf[:self.info['size']])
+                self._dict = pickle.loads(data)
+                # Keep a reference to the shared memory to prevent it from being garbage collected
+                self._shm = shm
+                self._loaded = True
+            except Exception as e:
+                print(f"Error loading shared dictionary: {e}")
+                # Ensure we have a valid dictionary even if loading fails
+                if not self._dict:
+                    self._dict = {}
+    
+    def __del__(self):
+        """Clean up shared memory when this object is garbage collected.
+        
+        This ensures that shared memory is released in worker processes.
+        Note: The main process still needs the atexit handler to clean up the
+        original shared memory block.
+        """
+        if hasattr(self, '_shm') and self._shm is not None:
+            try:
+                # Only close it - don't unlink as the main process manages that
+                self._shm.close()
+                self._shm = None
+            except Exception:
+                # Silently ignore errors during garbage collection
+                pass
+    
+    def get(self, key, default=None):
+        """Get a value for key, or default if key is not present.
+        
+        Args:
+            key: The key to look up
+            default: Value to return if key is not found
+            
+        Returns:
+            The value for key if present, otherwise default
+        """
+        self._load_dict()
+        return self._dict.get(key, default)
+    
+    def __getitem__(self, key):
+        """Get a value for key.
+        
+        Args:
+            key: The key to look up
+            
+        Returns:
+            The value for key
+            
+        Raises:
+            KeyError: If key is not found
+        """
+        self._load_dict()
+        return self._dict[key]
+    
+    def __contains__(self, key):
+        """Check if key is in the dictionary.
+        
+        Args:
+            key: The key to check for
+            
+        Returns:
+            bool: True if key is present, False otherwise
+        """
+        self._load_dict()
+        return key in self._dict
+    
+    def keys(self):
+        """Get the dictionary keys.
+        
+        Returns:
+            An iterable of keys
+        """
+        self._load_dict()
+        return self._dict.keys()
+    
+    def values(self):
+        """Get the dictionary values.
+        
+        Returns:
+            An iterable of values
+        """
+        self._load_dict()
+        return self._dict.values()
+    
+    def items(self):
+        """Get the dictionary items.
+        
+        Returns:
+            An iterable of (key, value) pairs
+        """
+        self._load_dict()
+        return self._dict.items()
+    
+    def __len__(self):
+        """Get the number of items in the dictionary.
+        
+        Returns:
+            int: Number of items
+        """
+        self._load_dict()
+        return len(self._dict)
+
+
+def convert_to_shared_dict(original_dict: Dict[str, Any], dict_id: Optional[str] = None) -> SharedDict:
+    """Convert a dictionary to a fast read-only shared memory structure.
+    
+    This implementation provides much faster read access than traditional 
+    shared dictionaries by using direct shared memory access. This approach 
+    is optimized for read-heavy workloads where the dictionary doesn't 
+    change after creation.
+    
+    For the best performance (close to local dictionary speed), each worker
+    process loads the dictionary into local memory on first access, giving
+    near-native speed for all subsequent lookups while still saving memory
+    across the main process.
+    
+    Args:
+        original_dict (dict): The regular Python dictionary to convert
+        dict_id (str, optional): Unique identifier for this shared dictionary.
+                                If None, a UUID will be generated.
+        
+    Returns:
+        SharedDict: A shared memory dictionary with fast read access
+    """
+    # Generate a unique ID if none provided
+    if dict_id is None:
+        dict_id = f"shared_dict_{uuid.uuid4().hex}"
+    
+    print(f"Converting dictionary '{dict_id}' to shared memory...")
+    
+    # Serialize the dictionary with pickle
+    serialized_dict = pickle.dumps(original_dict)
+    dict_size_bytes = len(serialized_dict)
+    
+    # Create a shared memory block to hold the serialized dictionary
+    shm = shared_memory.SharedMemory(create=True, size=dict_size_bytes)
+    
+    # Copy the serialized dictionary to shared memory
+    shm.buf[:dict_size_bytes] = serialized_dict
+    
+    # Store essential information for accessing the shared memory
+    shared_dict_info = {
+        'name': shm.name,
+        'size': dict_size_bytes
+    }
+    
+    # Keep reference to prevent garbage collection
+    global _shared_memory_blocks
+    _shared_memory_blocks[dict_id] = shm
+    
+    # Create a wrapper that provides dictionary-like access
+    result = SharedDict(shared_dict_info, dict_id)
+    
+    # Clear the original dictionary to free memory
+    original_dict.clear()
+    
+    # Force garbage collection to release memory
+    import gc
+    gc.collect()
+    
+    print(f"Shared memory conversion complete for '{dict_id}' ({dict_size_bytes/1024/1024:.1f} MB)")
+    
+    return result
+
+
+def release_shared_dict(dict_id: str) -> bool:
+    """Release a specific shared dictionary by its ID.
+    
+    Args:
+        dict_id (str): The ID of the shared dictionary to release
+        
+    Returns:
+        bool: True if the dictionary was successfully released, False otherwise
+    """
+    global _shared_memory_blocks
+    
+    if dict_id in _shared_memory_blocks:
+        try:
+            # Get the shared memory block
+            shm = _shared_memory_blocks.pop(dict_id)
+            # Close and unlink the shared memory
+            shm.close()
+            shm.unlink()
+            return True
+        except Exception as e:
+            print(f"Error releasing shared dictionary '{dict_id}': {e}")
+            # If an error occurred, put it back in the tracking dictionary
+            # so it will be cleaned up on exit
+            if dict_id not in _shared_memory_blocks and shm is not None:
+                _shared_memory_blocks[dict_id] = shm
+    
+    return False
+
+
+def get_shared_dict_ids() -> List[str]:
+    """Get a list of all shared dictionary IDs.
+    
+    Returns:
+        List[str]: List of shared dictionary IDs
+    """
+    global _shared_memory_blocks
+    return list(_shared_memory_blocks.keys())


### PR DESCRIPTION
## What does this PR do?

This PR is a side update when I'm using Protenix for creating new dataset for training/finetune. Which contains MSA script enhancement updates.

All changes in this PR includes:

- Add parameter arguments for all step scripts in MSA Generation for training/finetune
- Performance enhancement for Step 3 and Step 4 scripts. Both for memory and computation efficiency.
  - Multiprocessing for faster script processing.
  - Controllable Memory with faster speed when loading big `m8` files in Step 3 using parallel file reading with chunking.
  - Shared Memory for multiprocessing to control memory explosion when processing large dataset's MSA.
- Add date info supplement for Step 1 script when loading `cif` files transferring from pdb files (Which lack of sufficient information context)

Break Changes:

- None

Tests:

- Tested with original data in `script/msa/data` directory. All results remains unchanged.
- Tested performance with SAbDAb dataset. Which has around `9000` mmcif structures.
  - Generated ~30000 rows of records in pdb_seqs
  - Step 3 has a **strictly controlled memory occupation** since `m8` file is loaded by chunk.
  - Step 3 now needs **~1 min 30s** to load a **~170GB** m8 file and **~2min30s** to deal with all corresponding `a3m` files with **16 workers** (performance may limited by load/write speed of target filesystem).
  - Step 4 has around **~16000** records to be processed.  **~30 mins** with single thread processing. **~3min45s** with **16 workers** (performance may limited by load/write speed of target filesystem).

Here is a complete test file for step 3 to verify parallel reading of m8 file is consistent with single thread.

```python
# test_multiprocessing_consistency.py

import os
import tempfile
import shutil
import unittest
import random
import filecmp
import sys

# Add the parent directory to the Python path if needed
sys.path.append(os.path.dirname(os.path.abspath(__file__)))

# Import the functions to test
from step3_uniref_add_taxid import read_m8, process_files

class TestMultiprocessingConsistency(unittest.TestCase):
    """
    Test cases to verify that multiprocessing doesn't change the output results.
    """
    
    def setUp(self):
        """Set up test environment with temporary directories and test files."""
        # Create temporary directories
        self.temp_dir = tempfile.mkdtemp()
        self.input_dir = os.path.join(self.temp_dir, "input")
        self.output_dir1 = os.path.join(self.temp_dir, "output1")  # Sequential output
        self.output_dir2 = os.path.join(self.temp_dir, "output2")  # Multiprocessing output
        
        os.makedirs(self.input_dir, exist_ok=True)
        os.makedirs(self.output_dir1, exist_ok=True)
        os.makedirs(self.output_dir2, exist_ok=True)
        
        # Create test M8 file with controlled content
        self.m8_file = os.path.join(self.input_dir, "uniref_tax.m8")
        self._create_test_m8_file(self.m8_file, num_entries=1000000)
    
    def tearDown(self):
        """Clean up temporary directories."""
        shutil.rmtree(self.temp_dir)
    
    def _create_test_m8_file(self, filepath, num_entries=1000):
        """Create a test M8 file with controlled content."""
        with open(filepath, 'w') as f:
            # Write header or format information if needed
            
            # Generate controlled test data
            for i in range(num_entries):
                # Format: query_id, hit_name, ncbi_taxid, ...
                query_id = f"query_{i}"
                hit_name = f"UniRef100_{i}"
                ncbi_taxid = str(10000 + i)  # Create a unique taxid
                
                # Write the line
                f.write(f"{query_id}\t{hit_name}\t{ncbi_taxid}\n")

    def test_read_m8_consistency(self):
        """Test that read_m8 produces the same output with and without multiprocessing."""
        print("Testing read_m8 consistency...")
        
        # Run with multiprocessing
        print("Running with multiprocessing...")
        dict_mp = read_m8(
            m8_file=self.m8_file,
            max_workers=4,  # Use multiple workers
            block_size_mb=1  # Small block size to ensure multiple blocks
        )
        
        # Force running without multiprocessing by setting condition parameters
        print("Running without multiprocessing...")
        dict_seq = read_m8(
            m8_file=self.m8_file,
            max_workers=1,  # Single worker forces sequential
            block_size_mb=1000  # Large block size to ensure single block
        )
        
        # Compare the dictionaries
        self.assertEqual(len(dict_mp), len(dict_seq), 
                        f"Dictionary sizes differ: MP={len(dict_mp)}, Sequential={len(dict_seq)}")
        
        # Find missing entries
        if len(dict_mp) != len(dict_seq):
            print("\nMISSING ENTRIES ANALYSIS:")
            print(f"MP entries: {len(dict_mp)}, Sequential entries: {len(dict_seq)}")
            
            # Find entries in sequential but not in MP
            missing_from_mp = set(dict_seq.keys()) - set(dict_mp.keys())
            if missing_from_mp:
                print(f"Found {len(missing_from_mp)} entries missing from MP dictionary:")
                for key in missing_from_mp:
                    value = dict_seq[key]
                    print(f"  Missing key: '{key}', Value: '{value}'")
                    
                    # Let's also try to find this entry in the original file
                    print("\nSearching for the missing entry in the original file...")
                    with open(self.m8_file, 'r') as f:
                        for i, line in enumerate(f):
                            if key in line:
                                print(f"  Found at line {i+1}: {line.strip()}")
                                # Look at surrounding lines as well
                                f.seek(0)
                                start_line = max(0, i-5)
                                end_line = i+5
                                lines = [line.strip() for line in f.readlines()[start_line:end_line+1]]
                                print(f"  Context (lines {start_line+1}-{end_line+1}):")
                                for j, ctx_line in enumerate(lines):
                                    prefix = "→ " if j == (i - start_line) else "  "
                                    print(f"  {prefix}{start_line+j+1}: {ctx_line}")
                                break
                        else:
                            print("  Strange: Entry not found in original file!")
            
            # Find entries in MP but not in sequential
            extra_in_mp = set(dict_mp.keys()) - set(dict_seq.keys())
            if extra_in_mp:
                print(f"\nFound {len(extra_in_mp)} extra entries in MP dictionary:")
                for key in extra_in_mp:
                    print(f"  Extra key: '{key}', Value: '{dict_mp[key]}'")
        
        # Check that every key-value pair is identical
        for key, value in dict_mp.items():
            self.assertIn(key, dict_seq, f"Key '{key}' missing from sequential dictionary")
            self.assertEqual(value, dict_seq[key], 
                           f"Value mismatch for key '{key}': MP='{value}', Sequential='{dict_seq[key]}'")
        
        print(f"✓ Dictionaries are identical: {len(dict_mp)} entries")

if __name__ == "__main__":
    unittest.main()
```

As for other processing, the core logic stays unchanged without extra modification. Thus I just checked whether the number of generated files is identical.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?