### PR TITLE
Explicitly pass use_reentrant=False to torch checkpoint

### DIFF
--- a/protenix/openfold_local/utils/checkpointing.py
+++ b/protenix/openfold_local/utils/checkpointing.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from functools import partial
 import importlib
 from typing import Any, List, Callable, Optional
 
@@ -33,7 +34,7 @@ def get_checkpoint_fn():
     if deepspeed_is_configured:
         checkpoint = deepspeed.checkpointing.checkpoint
     else:
-        checkpoint = torch.utils.checkpoint.checkpoint
+        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
 
     return checkpoint
 


### PR DESCRIPTION
Using torch.utils.checkpoint without passing use_reentrant explicitly is deprecated and will become a hard error in the future. The recommended implementation is use_reentrant=False. This should work with everything afaict, but you should test to make sure before releasing.