### PR TITLE
delete a misleading comment in the file gen_ccd_cache.py

### DIFF
--- a/scripts/gen_ccd_cache.py
+++ b/scripts/gen_ccd_cache.py
@@ -155,8 +155,8 @@ def _get_component_rdkit_mol_processing(
         mol.ref_mask[:] = True
     except Exception:
         logging.warning(
-            "Warning: fail to generate conf for %s, use idea conf", ccd_code
-        )  # sanitization issue here
+            "Warning: fail to generate new conformation for %s, use the original ideal conformation.", ccd_code
+        )
     return mol
 
 


### PR DESCRIPTION
### 1. Before `conf_id = rdkit.Chem.AllChem.EmbedMolecule(mol, options)` executes,  we have checked `if mol.sanitized == False:`
### 2. After asking DeepSeek what modification will be made to "mol" if `conf_id = rdkit.Chem.AllChem.EmbedMolecule(mol, options)` executes successfully,  I don't understand what kind of sanitization issues might arise. 



### The following is the answer given by DeepSeek:
When `rdkit.Chem.AllChem.EmbedMolecule(mol, options)` executes **successfully**, it makes several key modifications to the `mol` object:

---

### **1. Adds a New Conformation**
- **Action**: Appends a new 3D conformation to the molecule's conformer list
- **Result**:
  ```python
  mol.GetNumConformers()  # Increases by 1 (e.g., from 0 → 1 or 1 → 2)
  ```
- **Accessing Coordinates**:
  ```python
  conf = mol.GetConformer(conf_id)  # conf_id is the index of the new conformer
  conf.GetPositions()  # Returns numpy array of (x,y,z) coordinates
  ```

---

### **2. Sets Specific Properties (In This Code)**
The surrounding code then modifies `mol` further:
```python
mol.ref_conf_id = conf_id       # Stores the index of the RDKit-generated conformer
mol.ref_conf_type = "rdkit"    # Marks conformation source as RDKit-generated
mol.ref_mask[:] = True         # Flags all atoms as having valid coordinates
```

---

### **Technical Details of What EmbedMolecule() Does**

#### **A. Coordinate Generation**
- Uses RDKit's **ETKDGv3** algorithm (Distance Geometry + Force Field optimization)
- Generates physically reasonable 3D coordinates _de novo_, ignoring any existing coordinates (unless `useRandomCoords=False`)

#### **B. Conformer Storage**
- The new conformer becomes **accessible via `conf_id`** (return value)
- Example for a molecule with 5 atoms:
  ```python
  conf = mol.GetConformer(conf_id)
  print(conf.GetAtomPosition(0))  # Returns a 3D point for atom 0
  ```

#### **C. Comparison to Original State**
| Property               | Before `EmbedMolecule()`          | After Success `EmbedMolecule()`       |
|------------------------|-----------------------------------|---------------------------------------|
| `mol.GetNumConformers()` | Likely 0 (unless pre-loaded)      | +1 new conformer                      |
| Coordinates            | Ideal CCD coords (if any)         | New RDKit-generated coords            |
| Energy State           | N/A                               | Locally minimized (ETKDGv3 includes MMFF94) |

---

### **Critical Note About `options.clearConfs=False`**
In this specific code:
```python
options.clearConfs = False  # Preserves existing conformers
```
- If the molecule already had a conformer (e.g., from CCD ideal coordinates), it will **retain** that conformer and add the new one
- `conf_id` will point to the **newly added** conformer, not the original one

---

### **Example Walkthrough**
For a molecule with 5 atoms:
1. **Before**:
   - 1 conformer (ideal coordinates from CCD, `ref_conf_id=0`)
   - `mol.GetNumConformers() == 1`

2. **After Successful EmbedMolecule()**:
   - 2 conformers:
     - `0`: Original ideal coordinates
     - `1`: New RDKit-generated coordinates
   - `conf_id` returns `1`
   - The code sets:
     ```python
     mol.ref_conf_id = 1          # Use the RDKit conformer
     mol.ref_conf_type = "rdkit"  # Mark as RDKit-generated
     ```

---

### **Why This Matters for Downstream Code**
The modifications enable:
1. **Fallback Mechanism**: If conformation fails, uses original (`ref_conf_type="idea"`)
2. **Coordinate Masking**: `ref_mask` tracks which atoms have valid coordinates
3. **Flexible Handling**: Can compare RDKit vs ideal conformations later

This design is particularly useful for handling both well-behaved organic molecules and problematic PDB components (metals, unusual bonding, etc.).