### PR TITLE
minor modification: switch `residue_index` to `token_index`

### DIFF
--- a/protenix/model/protenix.py
+++ b/protenix/model/protenix.py
@@ -386,7 +386,7 @@ class Protenix(nn.Module):
             tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]: Prediction, log, and time dictionaries.
         """
         step_st = time.time()
-        N_token = input_feature_dict["residue_index"].shape[-1]
+        N_token = input_feature_dict["token_index"].shape[-1]
 
         log_dict = {}
         pred_dict = {}


### PR DESCRIPTION
The actual effects are the same. It just helps you understand it.

In AF3 paper:
<img width="1396" height="171" alt="image" src="https://github.com/user-attachments/assets/3eed2876-8ec4-483c-a5c8-ffeeb9e4f434" />

For the first PDB entry `7r6r` in  examples\example.json:
<img width="641" height="391" alt="image" src="https://github.com/user-attachments/assets/49fba7e8-1a31-4956-943e-a99bffded8c3" />

<img width="1107" height="652" alt="image" src="https://github.com/user-attachments/assets/a406134d-3015-4e6d-8a7d-e5fbdc673d24" />
