### PR TITLE
fix: Add proper file handle management in colab_request_utils.py

### DIFF
--- a/protenix/web_service/colab_request_utils.py
+++ b/protenix/web_service/colab_request_utils.py
@@ -278,13 +278,15 @@ def run_mmseqs2_service(
                     env_a3m_fpath = os.path.join(
                         prefix, "bfd.mgnify30.metaeuk30.smag30.a3m"
                     )
-                    env_a3m_dict = parse_fasta_string(
-                        open(env_a3m_fpath, "r").read().replace("\x00", "")
-                    )
+                    with open(env_a3m_fpath, "r") as f:
+                        env_a3m_dict = parse_fasta_string(
+                            f.read().replace("\x00", "")
+                        )
                     uniref_a3m_fpath = os.path.join(prefix, "uniref.a3m")
-                    uniref_a3m_dict = parse_fasta_string(
-                        open(uniref_a3m_fpath, "r").read().replace("\x00", "")
-                    )
+                    with open(uniref_a3m_fpath, "r") as f:
+                        uniref_a3m_dict = parse_fasta_string(
+                            f.read().replace("\x00", "")
+                        )
                     query_id = str(int(x.split("\n")[0].split("_")[-1]))
                     query_seq = x.split("\n")[1]
                     real_non_pairing_fpath = os.path.join(
@@ -311,7 +313,8 @@ def run_mmseqs2_service(
                 else:
                     # pairing mode
                     pair_a3m = os.path.join(prefix, "pair.a3m")
-                    pair_a3m_chunks = open(pair_a3m, "r").read().split("\x00")
+                    with open(pair_a3m, "r") as f:
+                        pair_a3m_chunks = f.read().split("\x00")
                     for chunk in pair_a3m_chunks[:-1]:
                         real_pairing_fpath = os.path.join(
                             prefix,


### PR DESCRIPTION
## Summary

Fixes file handle leaks in `colab_request_utils.py` by using context managers for file operations.

## Problem

Three locations in `protenix/web_service/colab_request_utils.py` opened files without properly closing them:

```python
# Line 282-283
env_a3m_dict = parse_fasta_string(
    open(env_a3m_fpath, "r").read().replace("\x00", "")
)

# Line 286-287  
uniref_a3m_dict = parse_fasta_string(
    open(uniref_a3m_fpath, "r").read().replace("\x00", "")
)

# Line 314
pair_a3m_chunks = open(pair_a3m, "r").read().split("\x00")
```

### Why This Is Problematic

While Python's garbage collector will eventually close these files, relying on GC for resource cleanup causes several issues:

1. **File descriptor exhaustion**: File handles remain open until GC runs
   - Can hit OS limits (`ulimit -n`)
   - Especially problematic in long-running server processes
   - Can cause "Too many open files" errors

2. **Platform-specific issues**:
   - Windows holds exclusive locks on open files
   - Can prevent other processes from accessing files
   - May cause cleanup issues on network filesystems

3. **Unpredictable cleanup timing**:
   - GC runs at indeterminate times
   - Resource cleanup is delayed
   - Violates principle of immediate resource release

4. **Best practice violation**:
   - Contravenes PEP 343 (The "with" Statement)
   - Not following Python style guide recommendations
   - Makes code harder to maintain

## Solution

Replace direct `open()` calls with context managers (`with` statements):

### Before:
```python
env_a3m_dict = parse_fasta_string(
    open(env_a3m_fpath, "r").read().replace("\x00", "")
)
```

### After:
```python
with open(env_a3m_fpath, "r") as f:
    env_a3m_dict = parse_fasta_string(
        f.read().replace("\x00", "")
    )
```

## Changes Made

1. **Line 282-283**: Wrapped `env_a3m_fpath` file operation in context manager
2. **Line 286-287**: Wrapped `uniref_a3m_fpath` file operation in context manager  
3. **Line 314**: Wrapped `pair_a3m` file operation in context manager

## Impact

- **Low risk**: Only changes resource management, not functionality
- **Improved robustness**: Prevents file handle leaks
- **Better resource management**: Files closed immediately after use
- **Exception safety**: Context managers ensure cleanup even if exceptions occur
- **Follows best practices**: Aligns with Python style guidelines

## Test plan

- [x] Code review confirms files are properly closed
- [x] No functional changes to file reading logic
- [x] Context managers ensure cleanup on normal and exceptional exit
- [x] Compatible with existing error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)