### PR TITLE
triangular: Fix PyTorch 2.9 tensor indexing deprecation warnings

### DIFF
--- a/protenix/model/triangular/triangular.py
+++ b/protenix/model/triangular/triangular.py
@@ -333,7 +333,7 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
                 # Slices start:end from the dim dimension of t
                 s = empty_slicer(t)
                 s[dim] = slice(start, end)
-                return t[s]
+                return t[tuple(s)]
 
             def flip_z_cache_(z_cache, z):
                 # "Reorient" the z_cache (see below), filling it with quadrants
@@ -348,7 +348,7 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
                 # Move the 3rd quadrant of z into the
                 first_half_slicer = empty_slicer(z_cache)
                 first_half_slicer[col_dim] = slice(0, half_n)
-                z_cache[first_half_slicer] = quadrant_3
+                z_cache[tuple(first_half_slicer)] = quadrant_3
 
                 # Get the fourth quadrant of z
                 quadrant_4 = slice_tensor(z, half_n, None, row_dim)
@@ -358,7 +358,7 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
                 quadrant_3_slicer = empty_slicer(z_cache)
                 quadrant_3_slicer[col_dim] = slice(half_n, None)
 
-                z_cache[quadrant_3_slicer] = quadrant_4
+                z_cache[tuple(quadrant_3_slicer)] = quadrant_4
 
                 return z_cache
 
@@ -368,7 +368,7 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             z_cache = z.new_zeros(z_cache_shape)
             z_cache_slicer = empty_slicer(z_cache)
             z_cache_slicer[col_dim] = slice(0, half_n)
-            z_cache.copy_(z[z_cache_slicer])
+            z_cache.copy_(z[tuple(z_cache_slicer)])
             z_cache_rotated = False
 
             # We need to reorient the z-cache at the halfway point, and we
@@ -411,7 +411,7 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
                     if not z_cache_rotated:
                         z_chunk_slicer = empty_slicer(z_chunk_b)
                         z_chunk_slicer[col_dim] = slice(0, half_n)
-                        z_chunk_b[z_chunk_slicer] = slice_tensor(
+                        z_chunk_b[tuple(z_chunk_slicer)] = slice_tensor(
                             z_cache,
                             i,
                             i + offset,
@@ -449,9 +449,9 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
                 z_slicer = empty_slicer(z)
                 z_slicer[col_dim] = slice(i, i + offset)
                 if with_add:
-                    z[z_slicer] += x_chunk
+                    z[tuple(z_slicer)] += x_chunk
                 else:
-                    z[z_slicer] = x_chunk
+                    z[tuple(z_slicer)] = x_chunk
         else:
             b = compute_projection(z, mask, False, False)
             x = torch.matmul(a, b)


### PR DESCRIPTION
## Description

Fix deprecation warnings in [protenix/model/triangular/triangular.py](cci:7://file:///home/ullah/biotools/Protenix/protenix/model/triangular/triangular.py:0:0-0:0) for PyTorch 2.9+ compatibility.

**Problem:** During model inference, PyTorch 2.9 emits the following deprecation warning multiple times:

**Solution:** Convert all list-based tensor indexing to tuple-based indexing by wrapping slicers with `tuple()`.

Fixes #223

## Changes

All 6 locations in [_inference_forward()](cci:1://file:///home/ullah/biotools/Protenix/protenix/model/triangular/triangular.py:198:4-467:16) updated:

| Line | Function/Context | Change |
|------|------------------|--------|
| 336 | [slice_tensor()](cci:1://file:///home/ullah/biotools/Protenix/protenix/model/triangular/triangular.py:331:12-335:34) return | `return t[tuple(s)]` |
| 351 | [flip_z_cache_()](cci:1://file:///home/ullah/biotools/Protenix/protenix/model/triangular/triangular.py:337:12-362:30) first half | `z_cache[tuple(first_half_slicer)] = quadrant_3` |
| 361 | [flip_z_cache_()](cci:1://file:///home/ullah/biotools/Protenix/protenix/model/triangular/triangular.py:337:12-362:30) quadrant 3 | `z_cache[tuple(quadrant_3_slicer)] = quadrant_4` |
| 371 | z-cache initialization | `z_cache.copy_(z[tuple(z_cache_slicer)])` |
| 414 | z-chunk assignment | `z_chunk_b[tuple(z_chunk_slicer)] = slice_tensor(...)` |
| 452/454 | z-slicer add/assign | `z[tuple(z_slicer)] += x_chunk` / `= x_chunk` |

## Tested Successfully

**Full test details:** https://github.com/bytedance/Protenix/issues/223

**Environment:** PyTorch 2.10, CUDA 13.0, NVIDIA RTX 5090

## Verification Summary
- ✅ All deprecation warnings eliminated
- ✅ Inference runs successfully  
- ✅ Model forward times unchanged
- ✅ Output results identical (bit-for-bit)
- ✅ No performance regression
- ✅ All pre-commit checks passed (flake8, ufmt, pydoclint)