### PR TITLE
On-demand remote fetching of mmCIF template files

### DIFF
--- a/scripts/database/download_protenix_data.sh
+++ b/scripts/database/download_protenix_data.sh
@@ -62,12 +62,11 @@ fi
 info "Using PROTENIX_ROOT_DIR: $PROTENIX_ROOT_DIR"
 info "Download mode: $DOWNLOAD_MODE"
 mkdir -p "$PROTENIX_ROOT_DIR"
-
 # --- Download & Extract Data Components ---
 if [ "$DOWNLOAD_MODE" == "inference" ]; then
     DATA_FILES=(
         "common.tar.gz"
-        "mmcif.tar.gz"
+#        "mmcif.tar.gz"
         "search_database.tar.gz"
     )
 else

--- a/tests/test_fetch_remote_cif.py
+++ b/tests/test_fetch_remote_cif.py
@@ -1,0 +1,104 @@
+"""Tests for TemplateHitProcessor._fetch_or_read_cif with remote fetching."""
+
+import os
+import tempfile
+
+import pytest
+import requests
+
+from protenix.data.template.template_utils import TemplateHitProcessor
+
+
+@pytest.fixture
+def tmp_mmcif_dir(tmp_path):
+    """Create a temporary mmcif directory."""
+    d = tmp_path / "mmcif"
+    d.mkdir()
+    return str(d)
+
+
+class TestFetchOrReadCifLocal:
+    """Tests for local file reading (no network)."""
+
+    def test_reads_existing_local_file(self, tmp_mmcif_dir):
+        cif_path = os.path.join(tmp_mmcif_dir, "1abc.cif")
+        with open(cif_path, "w") as f:
+            f.write("LOCAL_CIF_CONTENT")
+
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=False)
+        result = proc._fetch_or_read_cif("1abc")
+        assert result == "LOCAL_CIF_CONTENT"
+
+    def test_local_preferred_over_remote(self, tmp_mmcif_dir):
+        """Even with fetch_remote=True, local file should be used if it exists."""
+        cif_path = os.path.join(tmp_mmcif_dir, "1abc.cif")
+        with open(cif_path, "w") as f:
+            f.write("LOCAL_CIF_CONTENT")
+
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=True)
+        result = proc._fetch_or_read_cif("1abc")
+        assert result == "LOCAL_CIF_CONTENT"
+
+    def test_raises_when_missing_and_fetch_remote_false(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=False)
+        with pytest.raises(FileNotFoundError, match="CIF not found"):
+            proc._fetch_or_read_cif("9zzz")
+
+
+class TestFetchOrReadCifRemote:
+    """Tests that actually hit the PDBe API (requires network)."""
+
+    @pytest.fixture(autouse=True)
+    def _check_network(self):
+        """Skip if PDBe is unreachable."""
+        try:
+            requests.head("https://www.ebi.ac.uk/pdbe/", timeout=5)
+        except requests.ConnectionError:
+            pytest.skip("PDBe unreachable, skipping remote tests")
+
+    def test_fetches_from_pdbe_and_caches(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=True)
+
+        result = proc._fetch_or_read_cif("1a2b")
+
+        assert len(result) > 1000, "Downloaded CIF should be a substantial file"
+        assert "data_" in result, "CIF content should contain a data_ block"
+
+        cached_path = os.path.join(tmp_mmcif_dir, "1a2b.cif")
+        assert os.path.exists(cached_path), "CIF should be cached locally"
+        with open(cached_path) as f:
+            assert f.read() == result, "Cached content should match returned content"
+
+    def test_second_call_uses_cache(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=True)
+
+        result1 = proc._fetch_or_read_cif("1a2b")
+        result2 = proc._fetch_or_read_cif("1a2b")
+        assert result1 == result2
+
+    def test_creates_mmcif_dir_if_missing(self, tmp_path):
+        new_dir = str(tmp_path / "nonexistent" / "mmcif")
+        assert not os.path.exists(new_dir)
+
+        proc = TemplateHitProcessor(mmcif_dir=new_dir, fetch_remote=True)
+        result = proc._fetch_or_read_cif("1a2b")
+
+        assert os.path.isdir(new_dir)
+        assert len(result) > 1000
+
+    def test_invalid_pdb_id_raises(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=True)
+        with pytest.raises(requests.HTTPError):
+            proc._fetch_or_read_cif("0000")
+
+
+class TestTemplateHitProcessorInit:
+    """Tests that fetch_remote plumbing works correctly."""
+
+    def test_default_fetch_remote_is_false(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir)
+        assert proc._fetch_remote is False
+
+    def test_fetch_remote_set_true(self, tmp_mmcif_dir):
+        proc = TemplateHitProcessor(mmcif_dir=tmp_mmcif_dir, fetch_remote=True)
+        assert proc._fetch_remote is True


### PR DESCRIPTION
## Summary

Adds on-demand remote fetching of mmCIF template files from PDBe, eliminating the need to pre-download the entire PDB mmCIF database (~80GB+) for template-based inference. This considerably reduces the size of the Docker container needed for inference only.

- **Remote mmCIF fetching**: When a template CIF is not found locally, it is automatically downloaded from `https://www.ebi.ac.uk/pdbe/entry-files/download/{pdb_id}.cif` and cached for future use. Local files are always preferred when available.
- **Smaller inference setup**: `mmcif.tar.gz` is removed from the inference download list in `download_protenix_data.sh`, since CIFs are now fetched individually on demand. This reduces considerably the size of the docker container needed for inference only.

## Changed files

| File | Change |
|------|--------|
| `protenix/data/template/template_utils.py` | New `_fetch_or_read_cif()` method on `TemplateHitProcessor` with local-first, remote-fallback logic. `fetch_remote` parameter threaded through `TemplateHitProcessor` and `TemplateHitFeaturizer`. |
| `protenix/data/inference/infer_dataloader.py` | mmCIF directory assertion gated on `fetch_remote=False`. Auto-creates mmcif dir when `fetch_remote=True`. Passes `fetch_remote` to `TemplateHitFeaturizer`. |
| `scripts/database/download_protenix_data.sh` | `mmcif.tar.gz` commented out of inference download list. |
| `tests/test_fetch_remote_cif.py` | New pytest suite covering local reads, remote fetching + caching, directory auto-creation, invalid PDB IDs, and flag plumbing. |

## Motivation

Running Protenix with `--use_template true` previously required downloading the full PDB mmCIF archive before inference could start. This made Docker images large and setup slow, especially for users who only need templates for a handful of structures. With this change, templates are fetched on demand from PDBe and cached locally, making the setup significantly simpler and the image much smaller.
