### PR TITLE
Auto-detect CUDA architectures for layer norm kernel compilation

### DIFF
--- a/protenix/model/layer_norm/torch_ext_compile.py
+++ b/protenix/model/layer_norm/torch_ext_compile.py
@@ -22,7 +22,38 @@ from torch.utils.cpp_extension import load
 def compile(
     name: str, sources: list[str], extra_include_paths: list[str], build_directory: str
 ) -> Any:
-    os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0;8.0"
+    # Query supported architectures from nvcc (resolved via PyTorch's
+    # CUDA_HOME so we use the same toolchain as cpp_extension.load).
+    import subprocess, re, shutil
+    from torch.utils.cpp_extension import CUDA_HOME
+
+    _nvcc = shutil.which("nvcc")
+    if CUDA_HOME:
+        _candidate = os.path.join(CUDA_HOME, "bin", "nvcc")
+        if os.path.isfile(_candidate):
+            _nvcc = _candidate
+
+    _supported = set()
+    try:
+        out = subprocess.check_output(
+            [_nvcc, "--list-gpu-arch"], text=True, stderr=subprocess.STDOUT
+        )
+        _supported = set(re.findall(r"compute_(\d+)", out))
+    except Exception:
+        _supported = {"70", "80", "86", "90"}  # safe defaults
+
+    _wanted = [("70", "70"), ("80", "80"), ("86", "86"), ("89", "89"), ("90", "90"), ("100", "100")]
+    gencode_flags = []
+    for compute, sm in _wanted:
+        if compute in _supported:
+            gencode_flags += ["-gencode", f"arch=compute_{compute},code=sm_{sm}"]
+    if not gencode_flags:
+        gencode_flags = ["-gencode", "arch=compute_80,code=sm_80"]
+
+    # Build TORCH_CUDA_ARCH_LIST dynamically from supported architectures
+    _arch_list = [f"{int(c)//10}.{int(c)%10}" for c, _ in _wanted if c in _supported]
+    os.environ["TORCH_CUDA_ARCH_LIST"] = ";".join(_arch_list) if _arch_list else "8.0"
+
     return load(
         name=name,
         sources=sources,
@@ -45,15 +76,7 @@ def compile(
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "--expt-relaxed-constexpr",
             "--expt-extended-lambda",
-            "-gencode",
-            "arch=compute_70,code=sm_70",
-            "-gencode",
-            "arch=compute_80,code=sm_80",
-            "-gencode",
-            "arch=compute_86,code=sm_86",
-            "-gencode",
-            "arch=compute_90,code=sm_90",
-        ],
+        ] + gencode_flags,
         verbose=True,
         build_directory=build_directory,
     )


### PR DESCRIPTION
## Summary

Replace hardcoded CUDA architecture flags with dynamic detection via `nvcc --list-gpu-arch`.

### Problem

`torch_ext_compile.py` hardcodes `TORCH_CUDA_ARCH_LIST = "7.0;8.0"` and emits fixed `-gencode` flags for sm_70/80/86/90. This fails or wastes compile time when:
- The local nvcc doesn't support some of those architectures
- Running on newer GPUs (sm_89 Ada Lovelace, sm_100 Blackwell) not in the hardcoded list

### What changed

| Before | After |
|---|---|
| `TORCH_CUDA_ARCH_LIST = "7.0;8.0"` | Dynamically built from `nvcc --list-gpu-arch` |
| 4 hardcoded `-gencode` flags (sm_70/80/86/90) | Only emit flags for architectures the local nvcc supports |
| Bare `nvcc` from PATH | Resolves nvcc via PyTorch's `CUDA_HOME` (same toolchain as `cpp_extension.load`) |
| No sm_89/sm_100 support | Adds Ada Lovelace (sm_89) and Blackwell (sm_100) |
| Fails silently on unsupported archs | Falls back to `{"70", "80", "86", "90"}` if detection fails, then sm_80 if empty |

### Corner cases handled

- **nvcc not on PATH**: Uses `CUDA_HOME/bin/nvcc` from PyTorch's `torch.utils.cpp_extension.CUDA_HOME`
- **Older nvcc without `--list-gpu-arch`** (pre-CUDA 11.5): Falls back to safe defaults matching original behavior
- **No nvcc at all**: Falls back to original gencode flags — but `cpp_extension.load()` itself will fail anyway

Supported target list: sm_70, sm_80, sm_86, sm_89, sm_90, sm_100 — filtered by what nvcc actually supports.