### PR TITLE
fix return identity matrix in eye_mask when opposite is False

### DIFF
--- a/protenix/utils/torch_utils.py
+++ b/protenix/utils/torch_utils.py
@@ -95,7 +95,7 @@ def eye_mask(L, device=None, opposite=False):
     if opposite:
         return 1.0 - torch.eye(L, device=device)
     else:
-        torch.eye(L, device=device)
+        return torch.eye(L, device=device)
 
 
 def glorot_uniform(t):


### PR DESCRIPTION
## Background

The `eye_mask()` function, in the `opposite=False` branch, only called `torch.eye(...)`, but lacked a `return` statement, causing the function to return `None`. This could lead to upstream mask calculations failing or to implicit errors.


## Modification

- In the `opposite=False` branch, add `return torch.eye(...)`.

