### PR TITLE
Remove invalid AdamW arg and handle None param_names

### DIFF
--- a/protenix/utils/training.py
+++ b/protenix/utils/training.py
@@ -74,14 +74,13 @@ def get_optimizer(
     configs, model: torch.nn.Module, param_names=None
 ) -> torch.optim.Optimizer:
     print("param_names: ", param_names)
-    if len(param_names) == 0 or param_names[0] == "":
+    if param_names is None or len(param_names) == 0 or param_names[0] == "":
         param_names = None
     if configs.adam.use_adamw:
         optimizer = get_adamw(
             model=model,
             weight_decay=configs.adam.weight_decay,
             learning_rate=configs.adam.lr,
-            other_learning_rate=configs.other_lr,
             betas=(configs.adam.beta1, configs.adam.beta2),
             device_type="cuda" if torch.cuda.is_available() else "cpu",
         )


### PR DESCRIPTION
## Background

The `training` module contains two related stability issues:

1. The `get_optimizer()` function triggers a `TypeError` when calling `get_adamw()` with a non-existent parameter `other_learning_rate`.

2. The input `get_optimizer(..., param_names=None)` is valid, but the original implementation directly uses `len(param_names)`, which triggers `TypeError: object of type 'NoneType' has no len()`.

## Modifications

- Removed the incorrect parameter passing to `get_adamw()`.

- Modified the `param_names` check to handle `None` first, then proceed with the length check logic.