### PR TITLE
docs: clarify latest PyPI installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Protenix is built for high-accuracy structure prediction. It serves as an initia
 ### 🛠 Quick Installation
 
 ```bash
-pip install protenix
+pip install --upgrade protenix --index-url https://pypi.org/simple
 ```
+
+If your package mirror lags behind the latest GitHub release, use the official PyPI index above to make sure the installed CLI matches the commands shown in this README.
 
 ### 🧬 Quick Prediction
 


### PR DESCRIPTION
## Summary
- update the README install command to explicitly upgrade from the official PyPI index
- add a short note explaining that lagging package mirrors can install an older CLI than the commands shown in the README

## Why
Issue #224 reports that users can see CLI behavior that does not match the README after installing from PyPI. From the discussion, the README commands match , but stale package mirrors can still surface an older published package. This change makes the install step more explicit so users are more likely to get the latest release.

Fixes #224