### PR TITLE
Add sm_120 (Blackwell consumer/workstation) gencode support

### DIFF
--- a/protenix/model/layer_norm/torch_ext_compile.py
+++ b/protenix/model/layer_norm/torch_ext_compile.py
@@ -55,6 +55,7 @@ def compile(
         ("89", "89"),
         ("90", "90"),
         ("100", "100"),
+        ("120", "120"),
     ]
     gencode_flags = []
     for compute, sm in _wanted:


### PR DESCRIPTION
## Summary
- Adds `compute_120/sm_120` to the gencode list in `torch_ext_compile.py`
- Enables Protenix to run on RTX PRO 6000 Blackwell, RTX 50 series, and other consumer/workstation Blackwell GPUs

## Background
RTX PRO 6000 Blackwell and RTX 50 series GPUs use compute capability 12.0 (sm_120), which is distinct from data center Blackwell (B100/B200, sm_100).

Without `sm_120` in the gencode list, the `fast_layer_norm_cuda_v2` extension is built without an sm_120 cubin, causing runtime failure:
CUDA error: no kernel image is available for execution on the device



## Test plan
- [x] Tested on NVIDIA RTX PRO 6000 Blackwell Max-Q (sm_120, 96GB) with CUDA 13.2 and PyTorch 2.11+cu130
- [x] `cuobjdump --list-elf` confirms `sm_120.cubin` is present in the built `.so`
- [x] Successfully ran `protenix pred` end-to-end

Closes #222