### PR TITLE
Add TFG contact restraints for JSON constraints

### DIFF
--- a/configs/configs_base.py
+++ b/configs/configs_base.py
@@ -221,6 +221,11 @@ model_configs = {
                     "angle_buffer": 0.00,
                     "clash_buffer": 0.00,
                 },
+                "UserDistanceRestraintPotential": {
+                    "interval": 1,
+                    "weight": 1.0,
+                    "enable_projection": False,
+                },
                 "ChiralAtomPotential": {
                     "interval": 1,
                     "weight": 0.0,

--- a/docs/infer_json_format.md
+++ b/docs/infer_json_format.md
@@ -255,6 +255,19 @@ The `contact` constraint allows you to specify residue/atom-residue/atom level p
 
 > 💡 *This is a **soft constraint**: the model is encouraged, but not strictly required, to satisfy it.*
 
+Model support differs by mechanism:
+
+- `protenix_base_constraint_v0.5.0` uses trained constraint embedders for JSON
+  `contact` and `pocket` constraints.
+- Protenix v1/v2 models do not include trained constraint embedders. For these
+  models, JSON `contact` constraints affect sampling only when Training-Free
+  Guidance is enabled with `--use_tfg_guidance true`.
+- Protenix v1/v2 `pocket` constraints are not converted to TFG restraints yet.
+  Use `protenix_base_constraint_v0.5.0` for pocket constraints.
+
+See [Training-Free Guidance](./tfg_guidance.md) for v1/v2 contact guidance
+examples and tuning notes.
+
 #### contact constraint
 
 The contact field is a list of dictionaries, each defining a distance constraint between two residues or specific atoms. The format uses explicit, named keys for clarity and flexibility.

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -50,6 +50,12 @@ Model names follow the format:
     - `contact_embedder`: Handles contact point information.
 - **Use Case**: Predictions with available structural priors.
 
+For Protenix v1/v2 models, trained constraint embedders are not enabled. JSON
+`contact` constraints can instead be used as Training-Free Guidance distance
+restraints with `--use_tfg_guidance true`; see
+[Training-Free Guidance](./tfg_guidance.md). JSON `pocket` constraints still
+require the v0.5 constraint model.
+
 ### 4. ESM & ISM Models
 - **Characteristics**: Integrates the single-sequence protein language model (ESM2-3B), performing better when MSAs are unavailable.
 - **Difference**: `ESM` uses standard ESM2 embeddings, while `ISM` uses specific ISM embeddings.

--- a/docs/tfg_guidance.md
+++ b/docs/tfg_guidance.md
@@ -1,0 +1,126 @@
+# Training-Free Guidance for User Contact Constraints
+
+Training-Free Guidance (TFG) applies differentiable energy terms during
+diffusion sampling. It is a sampling-time guidance mechanism, not a learned
+conditioning module.
+
+## Constraint Support by Model
+
+- `protenix_base_constraint_v0.5.0` uses the trained constraint embedder path
+  for JSON `constraint` inputs.
+- `protenix_base_default_v1.0.0`, `protenix_base_20250630_v1.0.0`, and
+  `protenix-v2` do not have trained constraint embedders enabled.
+- For v1/v2 models, JSON `constraint.contact` entries can be used as TFG
+  distance restraints by enabling TFG.
+- JSON `constraint.pocket` entries are not converted to TFG restraints yet for
+  v1/v2 models. Use the v0.5 constraint model for pocket constraints.
+
+TFG restraints are soft. They can bias sampling toward satisfying the specified
+distance bounds, but they do not guarantee satisfaction and can trade off with
+model confidence or geometry if weighted too strongly.
+
+## Contact Example
+
+Use the existing JSON `constraint.contact` format:
+
+```json
+[
+  {
+    "name": "example_tfg_contact",
+    "sequences": [
+      {
+        "proteinChain": {
+          "sequence": "AAAA",
+          "count": 1
+        }
+      },
+      {
+        "proteinChain": {
+          "sequence": "GGGG",
+          "count": 1
+        }
+      }
+    ],
+    "constraint": {
+      "contact": [
+        {
+          "entity1": 1,
+          "copy1": 1,
+          "position1": 2,
+          "entity2": 2,
+          "copy2": 1,
+          "position2": 3,
+          "max_distance": 8.0,
+          "min_distance": 0.0
+        }
+      ]
+    }
+  }
+]
+```
+
+Run with the Click CLI:
+
+```bash
+protenix pred \
+  -i examples/example_tfg_contact_v1.json \
+  -o ./output_tfg_contact \
+  -n protenix_base_default_v1.0.0 \
+  --use_tfg_guidance true \
+  --tfg_constraint_weight 1.0
+```
+
+Advanced users can tune through nested config overrides in `runner/inference.py`:
+
+```bash
+python3 runner/inference.py \
+  --model_name protenix_base_default_v1.0.0 \
+  --input_json_path examples/example_tfg_contact_v1.json \
+  --dump_dir ./output_tfg_contact \
+  --seeds 101 \
+  --sample_diffusion.N_sample 1 \
+  --sample_diffusion.N_step 200 \
+  --sample_diffusion.guidance.enable true \
+  --sample_diffusion.guidance.terms.UserDistanceRestraintPotential.weight 1.0
+```
+
+## Atom-Level Contacts
+
+For exact ligand or residue atom control, specify both atom names:
+
+```json
+{
+  "entity1": 1,
+  "copy1": 1,
+  "position1": 10,
+  "atom1": "CA",
+  "entity2": 2,
+  "copy2": 1,
+  "position2": 1,
+  "atom2": "C5",
+  "max_distance": 6.0,
+  "min_distance": 3.0
+}
+```
+
+When atom names are omitted, Protenix resolves the contact to deterministic
+token centre atoms. For ligands, atom-level contacts are recommended because
+ligands are represented by atom-level tokens.
+
+## Tuning
+
+- Start with `--sample_diffusion.N_sample 1` while tuning.
+- Increase `--tfg_constraint_weight` if restraints are consistently violated.
+- Decrease the weight if structures become distorted or confidence drops.
+- TFG adds work inside diffusion sampling, so guided runs are slower than
+  unguided runs.
+
+## Troubleshooting
+
+- If v1/v2 constraints are present but `--use_tfg_guidance` is false, they are
+  parsed but do not affect sampling.
+- If `constraint.pocket` is present with a v1/v2 model, it is logged as not yet
+  converted to TFG restraints.
+- If a contact cannot be resolved to input atoms, it is skipped and logged.
+- If duplicate contact entries give incompatible bounds for the same atom pair,
+  inference raises a validation error.

--- a/docs/training_inference_instructions.md
+++ b/docs/training_inference_instructions.md
@@ -106,6 +106,10 @@ protenix pred --input examples/input.json --use_msa false --enable_cache true
 - `--model_name`: Model variant selection (e.g., `protenix_base_default_v1.0.0`, `protenix_mini_default_v0.5.0`).
 - `--use_default_params`: (Default: `true`) Automatically configures cycles and steps based on the selected model. Set to `false` to manually override `--cycle` and `--step`.
 - `--use_tfg_guidance`: Enable Training-Free Guidance (TFG) for refined sampling.
+  For Protenix v1/v2 models, JSON `constraint.contact` entries are converted to
+  TFG distance restraints only when this flag is enabled. Use
+  `--tfg_constraint_weight` to tune their strength in `protenix pred`. See
+  [Training-Free Guidance](./tfg_guidance.md) for examples and limitations.
 - `--use_msa` / `--use_template` / `--use_rna_msa`: (Default: `true`/`false`/`false`) Toggle specific features for inference.
 - `--dtype`: Set data type to `bf16` (default) or `fp32`.
 - `--trimul_kernel` / `--triatt_kernel`: Choose specialized kernels (e.g., `cuequivariance`, `triattention`) for hardware acceleration.

--- a/examples/example_tfg_contact_v1.json
+++ b/examples/example_tfg_contact_v1.json
@@ -1,0 +1,33 @@
+[
+    {
+        "name": "example_tfg_contact_v1",
+        "sequences": [
+            {
+                "proteinChain": {
+                    "count": 1,
+                    "sequence": "AAAAAA"
+                }
+            },
+            {
+                "proteinChain": {
+                    "count": 1,
+                    "sequence": "GGGGGG"
+                }
+            }
+        ],
+        "constraint": {
+            "contact": [
+                {
+                    "entity1": 1,
+                    "copy1": 1,
+                    "position1": 3,
+                    "entity2": 2,
+                    "copy2": 1,
+                    "position2": 4,
+                    "max_distance": 8.0,
+                    "min_distance": 0.0
+                }
+            ]
+        }
+    }
+]

--- a/protenix/data/constraint/constraint_featurizer.py
+++ b/protenix/data/constraint/constraint_featurizer.py
@@ -99,6 +99,130 @@ class ConstraintFeatureGenerator:
         return pocket_pos
 
     @staticmethod
+    def empty_tfg_contact_restraint_features() -> dict[str, torch.Tensor]:
+        """Return stable empty feature tensors for TFG user contact restraints."""
+        return {
+            "user_distance_restraint_index": torch.empty((2, 0), dtype=torch.long),
+            "user_distance_restraint_lower_bound": torch.empty(
+                (0,), dtype=torch.float32
+            ),
+            "user_distance_restraint_upper_bound": torch.empty(
+                (0,), dtype=torch.float32
+            ),
+            "user_distance_restraint_weight": torch.empty((0,), dtype=torch.float32),
+        }
+
+    @staticmethod
+    def generate_tfg_contact_restraint_features(
+        token_array: TokenArray,
+        atom_array: AtomArray,
+        sequences: list[dict[str, Any]],
+        constraint_param: dict,
+    ) -> dict[str, torch.Tensor]:
+        """Convert JSON contact constraints into atom-pair TFG restraints.
+
+        The learned constraint embedder consumes token-pair feature matrices. TFG
+        potentials operate directly on atom coordinates, so this path resolves
+        each contact into a deterministic atom pair and preserves the user
+        distance interval.
+        """
+        contact_inputs = [
+            ConstraintFeatureGenerator._canonicalize_contact_format(sequences, pair)
+            for pair in constraint_param.get("contact", [])
+        ]
+        if len(contact_inputs) == 0:
+            return ConstraintFeatureGenerator.empty_tfg_contact_restraint_features()
+
+        atom_to_token_idx = {}
+        for token_idx, token in enumerate(token_array.tokens):
+            for atom_idx in token.atom_indices:
+                atom_to_token_idx[atom_idx] = token_idx
+
+        def _mask_to_atom(pair: dict[str, Any], side: str) -> int | None:
+            atom_mask = get_atom_mask_by_name(
+                atom_array=atom_array,
+                entity_id=pair[side][0],
+                copy_id=pair[side][1],
+                position=pair[side][2],
+                atom_name=pair[side][3],
+            )
+            atom_ids = np.nonzero(atom_mask)[0]
+            if pair["contact_type"] == "atom_contact" or pair[side][3] is not None:
+                if np.size(atom_ids) != 1:
+                    return None
+                return int(atom_ids[0])
+
+            token_ids = sorted(
+                {
+                    atom_to_token_idx[int(atom_id)]
+                    for atom_id in atom_ids
+                    if int(atom_id) in atom_to_token_idx
+                }
+            )
+            if len(token_ids) == 0:
+                return None
+            # Deterministic phase-1 behavior for residue-level contacts. Exact
+            # ligand atom control is available through atom-level contacts.
+            for atom_name in ("CA", "C1'"):
+                for token_id in token_ids:
+                    atom_idx = int(token_array.tokens[token_id].centre_atom_index)
+                    if atom_array.atom_name[atom_idx] == atom_name:
+                        return atom_idx
+            return int(token_array.tokens[token_ids[0]].centre_atom_index)
+
+        restraints: dict[tuple[int, int], tuple[float, float]] = {}
+        for i, pair in enumerate(contact_inputs):
+            atom_i = _mask_to_atom(pair, "id1")
+            atom_j = _mask_to_atom(pair, "id2")
+            if atom_i is None or atom_j is None:
+                logger.info(f"TFG contact restraint {i} not found for the input")
+                continue
+            if atom_i == atom_j:
+                logger.info(f"TFG contact restraint {i} resolved to the same atom")
+                continue
+
+            lower = float(pair["min_distance"])
+            upper = float(pair["max_distance"])
+            key = tuple(sorted((atom_i, atom_j)))
+            if key in restraints:
+                prev_lower, prev_upper = restraints[key]
+                lower = max(prev_lower, lower)
+                upper = min(prev_upper, upper)
+                if upper < lower:
+                    raise ValueError(
+                        "Conflicting distance restraints for atom pair "
+                        f"{key}: lower={lower}, upper={upper}"
+                    )
+            restraints[key] = (lower, upper)
+
+        if len(restraints) == 0:
+            return ConstraintFeatureGenerator.empty_tfg_contact_restraint_features()
+
+        indices = []
+        lower_bounds = []
+        upper_bounds = []
+        for (atom_i, atom_j), (lower, upper) in sorted(restraints.items()):
+            indices.append([atom_i, atom_j])
+            lower_bounds.append(lower)
+            upper_bounds.append(upper)
+
+        logger.info(f"Loaded TFG contact restraints: #pairs:{len(indices)}")
+        return {
+            "user_distance_restraint_index": torch.tensor(
+                indices, dtype=torch.long
+            ).T,
+            "user_distance_restraint_lower_bound": torch.tensor(
+                lower_bounds, dtype=torch.float32
+            ),
+            "user_distance_restraint_upper_bound": torch.tensor(
+                upper_bounds, dtype=torch.float32
+            ),
+            "user_distance_restraint_weight": torch.ones(
+                len(indices), dtype=torch.float32
+            ),
+        }
+
+    @staticmethod
     def _log_constraint_feature(
         atom_array: AtomArray, token_array: TokenArray, constraint_feature: dict
     ):

--- a/protenix/data/inference/json_to_feature.py
+++ b/protenix/data/inference/json_to_feature.py
@@ -400,5 +400,13 @@ class SampleDictToFeatures:
                 exclude_std_residue=True,
             )
             feature_dict.update(geometry_featurizer.get_features())
+            feature_dict.update(
+                ConstraintFeatureGenerator.generate_tfg_contact_restraint_features(
+                    token_array,
+                    atom_array,
+                    self.input_dict["sequences"],
+                    self.input_dict.get("constraint", {}),
+                )
+            )
 
         return feature_dict, atom_array, token_array

--- a/protenix/tfg/config.py
+++ b/protenix/tfg/config.py
@@ -152,6 +152,12 @@ _REQUIRED_FEATURES: dict[str, set[str]] = {
         "pairwise_distance_lower_bound",
         "ref_element",
     },
+    "UserDistanceRestraintPotential": {
+        "user_distance_restraint_index",
+        "user_distance_restraint_lower_bound",
+        "user_distance_restraint_upper_bound",
+        "user_distance_restraint_weight",
+    },
     "InterchainBondPotential": {"interchain_bond_index"},
     "VinaStericPotential": {
         "asym_id",

--- a/protenix/tfg/potentials.py
+++ b/protenix/tfg/potentials.py
@@ -796,6 +796,59 @@ class PairwiseDistancePotential(Potential):
 
 
 @register
+class UserDistanceRestraintPotential(Potential):
+    """User-provided flat-bottom distance restraints.
+
+    Unlike `PairwiseDistancePotential`, this term is not derived from RDKit
+    molecular bounds and does not reinterpret non-bonded pairs as clash
+    constraints. It directly applies the lower/upper distance interval provided
+    by inference JSON contact constraints.
+
+    Expected `feats`:
+        - `user_distance_restraint_index`: `[2, M]`
+        - `user_distance_restraint_lower_bound`: `[M]`
+        - `user_distance_restraint_upper_bound`: `[M]`
+        - `user_distance_restraint_weight`: `[M]`
+    """
+
+    def _eval(self, coords, feats, params, need_grad: bool):
+        idx = feats["user_distance_restraint_index"].to(
+            device=coords.device, dtype=torch.long
+        )
+        if idx.numel() == 0:
+            return (
+                _zeros_energy_and_grad(coords) if need_grad else _zeros_energy(coords)
+            )
+
+        lower = feats["user_distance_restraint_lower_bound"].to(
+            device=coords.device, dtype=coords.dtype
+        )
+        upper = feats["user_distance_restraint_upper_bound"].to(
+            device=coords.device, dtype=coords.dtype
+        )
+        weight = feats["user_distance_restraint_weight"].to(
+            device=coords.device, dtype=coords.dtype
+        )
+
+        n_pair = idx.shape[-1]
+        if not (
+            lower.shape == upper.shape == weight.shape == torch.Size([n_pair])
+        ):
+            raise ValueError(
+                "UserDistanceRestraintPotential feature shapes are inconsistent: "
+                f"index has {n_pair} pairs, lower={tuple(lower.shape)}, "
+                f"upper={tuple(upper.shape)}, weight={tuple(weight.shape)}"
+            )
+
+        value, grad_value = _distance_value_and_grad(coords, idx, need_grad)
+        e, dE = _flat_bottom_parabolic(value, weight, lower, upper)
+        if not need_grad:
+            return _sum_energy(e)
+        grad_atom = _aggregate_atom_gradients(coords, idx, grad_value, dE)
+        return _sum_energy(e), grad_atom
+
+
+@register
 class StereoBondPotential(Potential):
     """Stereo double-bond (cis/trans) constraint using |dihedral|.
 

--- a/runner/batch_inference.py
+++ b/runner/batch_inference.py
@@ -21,7 +21,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import click
 import tqdm
@@ -65,6 +65,87 @@ def init_logging() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
         filemode="w",
     )
+
+
+def _iter_json_tasks(json_path: str) -> list[dict[str, Any]]:
+    with open(json_path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if isinstance(payload, list):
+        return [task for task in payload if isinstance(task, dict)]
+    if isinstance(payload, dict):
+        return [payload]
+    return []
+
+
+def _summarize_constraint_usage(json_paths: list[str]) -> dict[str, int]:
+    summary = {
+        "tasks": 0,
+        "constraint_tasks": 0,
+        "contact_tasks": 0,
+        "pocket_tasks": 0,
+        "other_constraint_tasks": 0,
+    }
+    for json_path in json_paths:
+        for task in _iter_json_tasks(json_path):
+            summary["tasks"] += 1
+            constraint = task.get("constraint", {}) or {}
+            if not isinstance(constraint, dict) or len(constraint) == 0:
+                continue
+            summary["constraint_tasks"] += 1
+            if constraint.get("contact"):
+                summary["contact_tasks"] += 1
+            if constraint.get("pocket"):
+                summary["pocket_tasks"] += 1
+            if any(k not in {"contact", "pocket"} for k in constraint):
+                summary["other_constraint_tasks"] += 1
+    return summary
+
+
+def _log_constraint_guidance_status(
+    json_paths: list[str], model_name: str, use_tfg_guidance: bool
+) -> None:
+    summary = _summarize_constraint_usage(json_paths)
+    if summary["constraint_tasks"] == 0:
+        return
+
+    if model_name == "protenix_base_constraint_v0.5.0":
+        logger.info(
+            "Input contains JSON constraints for %d task(s); "
+            "using the trained v0.5 constraint embedder path.",
+            summary["constraint_tasks"],
+        )
+        return
+
+    if not use_tfg_guidance:
+        logger.warning(
+            "Input contains JSON constraints for %d task(s), but model %s does "
+            "not have trained constraint embedders enabled and TFG is disabled. "
+            "These constraints will not affect sampling. Enable "
+            "--use_tfg_guidance true to use contact constraints as TFG restraints.",
+            summary["constraint_tasks"],
+            model_name,
+        )
+        return
+
+    if summary["contact_tasks"] > 0:
+        logger.info(
+            "Using JSON contact constraints as TFG distance restraints for %d task(s).",
+            summary["contact_tasks"],
+        )
+    if summary["pocket_tasks"] > 0:
+        logger.warning(
+            "Input contains pocket constraints for %d task(s). Pocket constraints "
+            "are not converted to TFG restraints yet for model %s, so they will "
+            "not affect sampling unless a trained constraint embedder is active.",
+            summary["pocket_tasks"],
+            model_name,
+        )
+    if summary["other_constraint_tasks"] > 0:
+        logger.warning(
+            "Input contains unsupported constraint keys for %d task(s); only "
+            "contact constraints are converted to TFG restraints for this model.",
+            summary["other_constraint_tasks"],
+        )
 
 
 def preprocess_input(
@@ -303,6 +384,7 @@ def get_default_runner(
     need_atom_confidence: bool = False,
     kalign_binary_path: Optional[str] = None,
     use_tfg_guidance: bool = False,
+    tfg_constraint_weight: Optional[float] = None,
 ) -> InferenceRunner:
     """
     Get a default InferenceRunner with the specified configurations.
@@ -325,6 +407,7 @@ def get_default_runner(
         use_seeds_in_json (bool): Whether to use seeds defined in the JSON file.
         kalign_binary_path (Optional[str]): Path to kalign binary.
         use_tfg_guidance (bool): Whether to use TFG guidance.
+        tfg_constraint_weight (Optional[float]): Weight for user contact TFG restraints.
 
     Returns:
         InferenceRunner: An instance of InferenceRunner.
@@ -373,6 +456,10 @@ def get_default_runner(
     configs.use_rna_msa = use_rna_msa
     configs.use_seeds_in_json = use_seeds_in_json
     configs.need_atom_confidence = need_atom_confidence
+    if tfg_constraint_weight is not None:
+        configs.sample_diffusion.guidance.terms.UserDistanceRestraintPotential.weight = (
+            tfg_constraint_weight
+        )
     if kalign_binary_path is not None:
         # The path provided by the user is expected to exist by default
         configs.data.template.kalign_binary_path = kalign_binary_path
@@ -450,6 +537,7 @@ def inference_jsons(
     need_atom_confidence: bool = False,
     kalign_binary_path: Optional[str] = None,
     use_tfg_guidance: bool = False,
+    tfg_constraint_weight: Optional[float] = None,
     hmmsearch_binary_path: Optional[str] = None,
     hmmbuild_binary_path: Optional[str] = None,
     seqres_database_path: Optional[str] = None,
@@ -485,6 +573,7 @@ def inference_jsons(
         use_seeds_in_json (bool): Whether to use seeds from JSON.
         kalign_binary_path (Optional[str]): Path to kalign binary.
         use_tfg_guidance (bool): Use TFG guidance.
+        tfg_constraint_weight (Optional[float]): Weight for user contact TFG restraints.
         hmmsearch_binary_path (Optional[str]): Path to hmmsearch binary.
         hmmbuild_binary_path (Optional[str]): Path to hmmbuild binary.
         seqres_database_path (Optional[str]): Path to sequence database.
@@ -511,6 +600,7 @@ def inference_jsons(
     logger.info(f"Will infer with {len(infer_jsons)} jsons")
     if len(infer_jsons) == 0:
         return
+    _log_constraint_guidance_status(infer_jsons, model_name, use_tfg_guidance)
 
     infer_errors = {}
     inference_configs["dump_dir"] = out_dir
@@ -533,6 +623,7 @@ def inference_jsons(
         need_atom_confidence=need_atom_confidence,
         kalign_binary_path=kalign_binary_path,
         use_tfg_guidance=use_tfg_guidance,
+        tfg_constraint_weight=tfg_constraint_weight,
     )
     configs = runner.configs
     for _, infer_json in enumerate(tqdm.tqdm(infer_jsons)):
@@ -701,6 +792,12 @@ def protenix_cli() -> None:
     help="Use Training-Free Guidance (TFG) for inference.",
 )
 @click.option(
+    "--tfg_constraint_weight",
+    type=float,
+    default=1.0,
+    help="Weight for JSON contact constraints converted to TFG distance restraints.",
+)
+@click.option(
     "--hmmsearch_binary_path",
     type=str,
     default=None,
@@ -783,6 +880,7 @@ def predict(
     need_atom_confidence: bool,
     kalign_binary_path: Optional[str] = None,
     use_tfg_guidance: bool = False,
+    tfg_constraint_weight: float = 1.0,
     hmmsearch_binary_path: Optional[str] = None,
     hmmbuild_binary_path: Optional[str] = None,
     seqres_database_path: Optional[str] = None,
@@ -820,6 +918,7 @@ def predict(
         need_atom_confidence (bool): Compute atom-level confidence scores.
         kalign_binary_path (Optional[str]): Path to kalign binary.
         use_tfg_guidance (bool): Use TFG guidance.
+        tfg_constraint_weight (float): Weight for user contact TFG restraints.
         hmmsearch_binary_path (Optional[str]): Path to hmmsearch binary.
         hmmbuild_binary_path (Optional[str]): Path to hmmbuild binary.
         seqres_database_path (Optional[str]): Path to sequence database.
@@ -940,6 +1039,7 @@ def predict(
         need_atom_confidence=need_atom_confidence,
         kalign_binary_path=kalign_binary_path,
         use_tfg_guidance=use_tfg_guidance,
+        tfg_constraint_weight=tfg_constraint_weight,
         hmmsearch_binary_path=hmmsearch_binary_path,
         hmmbuild_binary_path=hmmbuild_binary_path,
         seqres_database_path=seqres_database_path,

--- a/tests/test_tfg_user_restraints.py
+++ b/tests/test_tfg_user_restraints.py
@@ -1,0 +1,287 @@
+import numpy as np
+import pytest
+import torch
+
+
+def _user_distance_restraint_potential():
+    pytest.importorskip("rdkit")
+    from protenix.tfg.potentials import UserDistanceRestraintPotential
+
+    return UserDistanceRestraintPotential()
+
+
+def _feature_dict(index, lower, upper, weight=None):
+    if weight is None:
+        weight = [1.0] * len(lower)
+    return {
+        "user_distance_restraint_index": torch.tensor(index, dtype=torch.long),
+        "user_distance_restraint_lower_bound": torch.tensor(
+            lower, dtype=torch.float32
+        ),
+        "user_distance_restraint_upper_bound": torch.tensor(
+            upper, dtype=torch.float32
+        ),
+        "user_distance_restraint_weight": torch.tensor(weight, dtype=torch.float32),
+    }
+
+
+def _empty_user_restraint_features():
+    return {
+        "user_distance_restraint_index": torch.empty((2, 0), dtype=torch.long),
+        "user_distance_restraint_lower_bound": torch.empty((0,), dtype=torch.float32),
+        "user_distance_restraint_upper_bound": torch.empty((0,), dtype=torch.float32),
+        "user_distance_restraint_weight": torch.empty((0,), dtype=torch.float32),
+    }
+
+
+def test_user_distance_restraint_empty_features_return_zero():
+    potential = _user_distance_restraint_potential()
+    coords = torch.zeros((3, 3), dtype=torch.float32)
+    feats = _empty_user_restraint_features()
+
+    energy, grad = potential.energy_and_grad(coords, feats)
+
+    torch.testing.assert_close(energy, torch.tensor(0.0))
+    torch.testing.assert_close(grad, torch.zeros_like(coords))
+
+
+def test_user_distance_restraint_upper_bound_violation_gradient():
+    potential = _user_distance_restraint_potential()
+    coords = torch.tensor([[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]])
+    feats = _feature_dict([[0], [1]], lower=[0.0], upper=[3.0])
+
+    energy, grad = potential.energy_and_grad(coords, feats)
+
+    torch.testing.assert_close(energy, torch.tensor(0.5))
+    assert grad[0, 0] < 0.0
+    assert grad[1, 0] > 0.0
+
+
+def test_user_distance_restraint_lower_bound_violation_gradient():
+    potential = _user_distance_restraint_potential()
+    coords = torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    feats = _feature_dict([[0], [1]], lower=[2.0], upper=[4.0])
+
+    energy, grad = potential.energy_and_grad(coords, feats)
+
+    torch.testing.assert_close(energy, torch.tensor(0.5))
+    assert grad[0, 0] > 0.0
+    assert grad[1, 0] < 0.0
+
+
+def test_user_distance_restraint_zero_inside_bounds_and_weight_scaling():
+    potential = _user_distance_restraint_potential()
+    coords = torch.tensor([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+    inside = _feature_dict([[0], [1]], lower=[2.0], upper=[4.0], weight=[2.0])
+    outside = _feature_dict([[0], [1]], lower=[0.0], upper=[2.0], weight=[2.0])
+
+    torch.testing.assert_close(potential.energy(coords, inside), torch.tensor(0.0))
+    torch.testing.assert_close(potential.energy(coords, outside), torch.tensor(1.0))
+
+
+def test_user_distance_restraint_supports_batch_dimensions():
+    potential = _user_distance_restraint_potential()
+    coords = torch.tensor(
+        [
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+        ]
+    )
+    feats = _feature_dict([[0], [1]], lower=[0.0], upper=[3.0])
+
+    energy = potential.energy(coords, feats)
+
+    torch.testing.assert_close(energy, torch.tensor([0.5, 0.0]))
+
+
+class DummyAtomArray:
+    def __init__(self):
+        self.shape = (4,)
+        self.label_entity_id = np.array(["1", "1", "2", "2"])
+        self.copy_id = np.array([1, 1, 1, 1])
+        self.res_id = np.array([10, 10, 20, 20])
+        self.atom_name = np.array(["CA", "CB", "N", "C"])
+
+
+def _token_array():
+    pytest.importorskip("biotite")
+    from protenix.data.tokenizer import Token, TokenArray
+
+    token1 = Token(1)
+    token1.atom_indices = [0, 1]
+    token1.atom_names = ["CA", "CB"]
+    token1.centre_atom_index = 0
+    token2 = Token(1)
+    token2.atom_indices = [2, 3]
+    token2.atom_names = ["N", "C"]
+    token2.centre_atom_index = 2
+    return TokenArray([token1, token2])
+
+
+def test_tfg_contact_features_resolve_atom_contacts_exactly():
+    pytest.importorskip("biotite")
+    from protenix.data.constraint.constraint_featurizer import ConstraintFeatureGenerator
+
+    constraint = {
+        "contact": [
+            {
+                "entity1": 1,
+                "copy1": 1,
+                "position1": 10,
+                "atom1": "CB",
+                "entity2": 2,
+                "copy2": 1,
+                "position2": 20,
+                "atom2": "C",
+                "min_distance": 2.0,
+                "max_distance": 6.0,
+            }
+        ]
+    }
+
+    feats = ConstraintFeatureGenerator.generate_tfg_contact_restraint_features(
+        _token_array(), DummyAtomArray(), [{}, {}], constraint
+    )
+
+    torch.testing.assert_close(
+        feats["user_distance_restraint_index"], torch.tensor([[1], [3]])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_lower_bound"], torch.tensor([2.0])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_upper_bound"], torch.tensor([6.0])
+    )
+
+
+def test_tfg_contact_features_resolve_token_contacts_to_centre_atoms():
+    pytest.importorskip("biotite")
+    from protenix.data.constraint.constraint_featurizer import ConstraintFeatureGenerator
+
+    constraint = {
+        "contact": [
+            {
+                "entity1": 1,
+                "copy1": 1,
+                "position1": 10,
+                "entity2": 2,
+                "copy2": 1,
+                "position2": 20,
+                "min_distance": 1.5,
+                "max_distance": 7.0,
+            }
+        ]
+    }
+
+    feats = ConstraintFeatureGenerator.generate_tfg_contact_restraint_features(
+        _token_array(), DummyAtomArray(), [{}, {}], constraint
+    )
+
+    torch.testing.assert_close(
+        feats["user_distance_restraint_index"], torch.tensor([[0], [2]])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_lower_bound"], torch.tensor([1.5])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_upper_bound"], torch.tensor([7.0])
+    )
+
+
+def test_tfg_contact_features_preserve_mixed_atom_residue_contacts():
+    pytest.importorskip("biotite")
+    from protenix.data.constraint.constraint_featurizer import ConstraintFeatureGenerator
+
+    constraint = {
+        "contact": [
+            {
+                "entity1": 1,
+                "copy1": 1,
+                "position1": 10,
+                "atom1": "CB",
+                "entity2": 2,
+                "copy2": 1,
+                "position2": 20,
+                "min_distance": 2.5,
+                "max_distance": 6.5,
+            }
+        ]
+    }
+
+    feats = ConstraintFeatureGenerator.generate_tfg_contact_restraint_features(
+        _token_array(), DummyAtomArray(), [{}, {}], constraint
+    )
+
+    torch.testing.assert_close(
+        feats["user_distance_restraint_index"], torch.tensor([[1], [2]])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_lower_bound"], torch.tensor([2.5])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_upper_bound"], torch.tensor([6.5])
+    )
+
+
+def test_tfg_contact_features_deduplicate_with_tightest_interval():
+    pytest.importorskip("biotite")
+    from protenix.data.constraint.constraint_featurizer import ConstraintFeatureGenerator
+
+    constraint = {
+        "contact": [
+            {
+                "entity1": 1,
+                "copy1": 1,
+                "position1": 10,
+                "entity2": 2,
+                "copy2": 1,
+                "position2": 20,
+                "min_distance": 1.0,
+                "max_distance": 8.0,
+            },
+            {
+                "entity1": 2,
+                "copy1": 1,
+                "position1": 20,
+                "entity2": 1,
+                "copy2": 1,
+                "position2": 10,
+                "min_distance": 2.0,
+                "max_distance": 5.0,
+            },
+        ]
+    }
+
+    feats = ConstraintFeatureGenerator.generate_tfg_contact_restraint_features(
+        _token_array(), DummyAtomArray(), [{}, {}], constraint
+    )
+
+    torch.testing.assert_close(
+        feats["user_distance_restraint_index"], torch.tensor([[0], [2]])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_lower_bound"], torch.tensor([2.0])
+    )
+    torch.testing.assert_close(
+        feats["user_distance_restraint_upper_bound"], torch.tensor([5.0])
+    )
+
+
+def test_tfg_config_validates_user_restraint_features():
+    pytest.importorskip("rdkit")
+    from protenix.tfg.config import parse_tfg_config, validate_features
+
+    cfg = parse_tfg_config(
+        {
+            "enable": True,
+            "terms": {
+                "UserDistanceRestraintPotential": {
+                    "interval": 1,
+                    "weight": 1.0,
+                }
+            },
+        }
+    )
+    feats = _empty_user_restraint_features()
+
+    validate_features(feats, cfg.terms)


### PR DESCRIPTION
## Summary

Addresses #307 by adding a supported Training-Free Guidance (TFG) path for JSON `constraint.contact` inputs on Protenix v1/v2 models without enabling untrained constraint embedders.

This PR:
- adds `UserDistanceRestraintPotential`, a flat-bottom pairwise distance restraint term for user-provided contact bounds
- converts inference JSON `constraint.contact` entries into atom-pair TFG restraint features when TFG feature extraction is enabled
- supports residue-residue, atom-atom, and mixed atom-residue contact formats
- adds a `--tfg_constraint_weight` CLI knob for tuning restraint strength
- warns users when JSON constraints are present but the selected model/path will not consume them
- documents the v0.5 learned-constraint path versus the v1/v2 TFG contact-restraint path
- adds a runnable v1 contact-constraint example and focused tests

## Root Cause

The v1/v2 checkpoints do not have trained `ConstraintEmbedder` modules enabled, so JSON constraints can be parsed without actually conditioning diffusion sampling. The existing TFG framework already supports differentiable geometry terms, but JSON contact constraints were not converted into TFG-compatible atom-pair features.

## Implementation Notes

The new restraint path is intentionally narrow:
- it does not turn on untrained constraint embedders for v1/v2 models
- it does not reinterpret user contacts as RDKit pairwise geometry bounds
- it preserves user-provided min/max distances as soft flat-bottom TFG penalties
- it keeps `constraint.pocket` unsupported for v1/v2 TFG and documents that limitation

## Validation

- `python3 -m py_compile protenix/tfg/potentials.py protenix/tfg/config.py protenix/data/constraint/constraint_featurizer.py protenix/data/inference/json_to_feature.py runner/batch_inference.py tests/test_tfg_user_restraints.py`
- `git diff --check`
- `git diff --cached --check`
- `python3 -m json.tool examples/example_tfg_contact_v1.json`
- manual smoke test for `UserDistanceRestraintPotential` energy and gradient direction
- `python -m pytest tests/test_tfg_user_restraints.py -q`

The focused pytest file collected successfully in the local environment, but all tests were skipped because the local Python environment is missing optional Protenix chemistry dependencies such as RDKit/Biotite. `uv run pytest ...` is also blocked locally by an existing invalid Anaconda `llvmlite` egg-info version, before test execution begins.
