### PR TITLE
Add native score-only confidence CLI for existing structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ If your package mirror lags behind the latest GitHub release, use the official P
 protenix pred -i examples/input.json -o ./output -n protenix_base_default_v1.0.0
 ```
 
+### 🧪 Quick Structure Scoring
+
+```bash
+# Score an existing PDB or CIF structure without diffusion sampling
+protenix score -i examples/7pzb.pdb -o ./score_output -n protenix_base_default_v1.0.0
+```
+
+The scoring command reuses Protenix input preprocessing, runs the trunk and
+confidence heads on the supplied atom coordinates, and writes confidence outputs
+such as `summary.csv` and per-structure `summary_confidence.json`.
+
 #### Key Model Descriptions
 | Model Name | MSA | RNA MSA | Template | Params | Training Data Cutoff | Model Release Date |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: |

--- a/docs/training_inference_instructions.md
+++ b/docs/training_inference_instructions.md
@@ -48,6 +48,7 @@ Protenix provides a unified CLI for structure prediction, data preprocessing, an
 | Command | Alias | Description |
 |---------|-------|-------------|
 | `predict` | `pred` | Perform model inference on JSON input(s). |
+| `score` | `score` | Score existing PDB/CIF coordinates with Protenix confidence heads. |
 | `tojson` | `json` | Convert PDB or CIF files to Protenix-compatible JSON. |
 | `msa` | `msa` | Generate Multiple Sequence Alignments (MSA) for proteins. |
 | `msatemplate` | `mt` | Run sequential MSA and template search. |
@@ -110,6 +111,41 @@ protenix pred --input examples/input.json --use_msa false --enable_cache true
 - `--dtype`: Set data type to `bf16` (default) or `fp32`.
 - `--trimul_kernel` / `--triatt_kernel`: Choose specialized kernels (e.g., `cuequivariance`, `triattention`) for hardware acceleration.
 - `--enable_cache` / `--enable_fusion`: Enable memory/speed optimizations (recommended for GPU).
+
+### 4. Structure Scoring (`score`)
+Score fixed PDB or CIF coordinates without running diffusion sampling.
+```bash
+# Score one structure and write summary confidence files
+protenix score -i examples/7pzb.pdb -o ./score_output -n protenix_base_default_v1.0.0
+
+# Score a directory of structures recursively
+protenix score -i ./structures -o ./score_output --recursive --glob "*.pdb,*.cif"
+
+# Also write per-atom confidence and a scored CIF with pLDDT B-factors
+protenix score -i examples/7pzb.cif -o ./score_output --write_full_confidence --write_scored_cif
+```
+
+`score` parses the source structure, generates a Protenix input JSON, preserves
+source chain IDs when they are unique, reorders source coordinates into the
+featurized atom order, and runs the Pairformer trunk plus confidence heads. It
+does not use `--step`, `--sample`, or random seeds because diffusion sampling is
+skipped.
+
+Default outputs are:
+- `summary.csv`: one row per scored structure.
+- `<sample>/summary_confidence.json`: summary confidence metrics for the source coordinates.
+- `<sample>/chain_id_map.json`: source-to-featurized chain mapping.
+- `failed_records.txt`: only written when one or more structures fail.
+
+Optional outputs are:
+- `<sample>/full_confidence.json` with `--write_full_confidence`.
+- `<sample>/scored.cif` with `--write_scored_cif`.
+- `<sample>/missing_atoms.json` when fallback coordinates are used for missing atoms.
+
+By default, `--missing_atom_policy error` fails if Protenix expects atoms that
+are absent from the source structure. Use `--missing_atom_policy reference` or
+`--missing_atom_policy zero` only when those fallback coordinates are acceptable
+for your analysis.
 
 ### Inference via Bash Script
 Alternatively, use the provided demo script for automated runs:

--- a/protenix/data/inference/structure_scoring.py
+++ b/protenix/data/inference/structure_scoring.py
@@ -1,0 +1,346 @@
+# Copyright 2024 ByteDance and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fnmatch
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+import numpy as np
+from biotite.structure import AtomArray, get_chain_starts
+
+from protenix.data.core.filter import Filter
+from protenix.data.core.parser import MMCIFParser
+from protenix.data.inference.json_maker import atom_array_to_input_json
+from protenix.data.utils import pdb_to_cif
+
+SUPPORTED_STRUCTURE_SUFFIXES = {".cif", ".pdb"}
+MISSING_ATOM_POLICIES = {"error", "reference", "zero"}
+
+
+def sanitize_sample_name(name: str, max_length: int = 60) -> str:
+    """
+    Convert a file stem into a stable sample/output name.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._")
+    return (safe or "sample")[:max_length]
+
+
+def collect_structure_files(
+    input_path: str | os.PathLike[str],
+    recursive: bool = False,
+    globs: Optional[Sequence[str]] = None,
+) -> list[Path]:
+    """
+    Collect PDB/mmCIF structures from a file or directory.
+    """
+    root = Path(input_path)
+    if not root.exists():
+        raise RuntimeError(f"input path {input_path} does not exist")
+    if root.is_file():
+        paths = [root]
+    else:
+        paths = [path for path in (root.rglob("*") if recursive else root.glob("*"))]
+
+    patterns = [pattern.strip() for pattern in globs or [] if pattern.strip()]
+    files = []
+    seen = set()
+    for path in paths:
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in SUPPORTED_STRUCTURE_SUFFIXES:
+            continue
+        if patterns and not any(
+            fnmatch.fnmatch(path.name, pattern)
+            or fnmatch.fnmatch(path.name.lower(), pattern.lower())
+            for pattern in patterns
+        ):
+            continue
+        resolved = path.resolve()
+        if resolved not in seen:
+            files.append(resolved)
+            seen.add(resolved)
+    return sorted(files)
+
+
+def copy_label_asym_ids_to_entity_ids(input_json: dict[str, Any]) -> bool:
+    """
+    Preserve source chain IDs when every chain has a unique label_asym_id.
+
+    The inference JSON reader already accepts an optional per-entity ``id`` list.
+    ``json_maker`` records source ``label_asym_id`` values but does not copy them
+    to ``id``; scoring needs that preservation so supplied coordinates can be
+    mapped back to the featurized AtomArray.
+    """
+    pending_ids = []
+    all_ids = []
+    for _, entity in iter_entity_dicts(input_json):
+        label_ids = entity.get("label_asym_id")
+        count = int(entity.get("count", 1))
+        if label_ids is None or len(label_ids) != count:
+            return False
+        label_ids = [str(label_id) for label_id in label_ids]
+        if len(set(label_ids)) != len(label_ids):
+            return False
+        pending_ids.append((entity, label_ids))
+        all_ids.extend(label_ids)
+
+    if not pending_ids or len(set(all_ids)) != len(all_ids):
+        return False
+
+    for entity, label_ids in pending_ids:
+        entity["id"] = label_ids
+    return True
+
+
+def iter_entity_dicts(
+    input_json: dict[str, Any],
+) -> Iterable[tuple[str, dict[str, Any]]]:
+    """
+    Yield ``(entity_type, entity_dict)`` pairs from a Protenix input JSON sample.
+    """
+    for sequence in input_json.get("sequences", []):
+        if len(sequence) != 1:
+            raise RuntimeError(f"invalid sequence entity: {sequence}")
+        entity_type, entity = next(iter(sequence.items()))
+        yield entity_type, entity
+
+
+def structure_to_score_input_json(
+    input_file: str | os.PathLike[str],
+    sample_name: Optional[str] = None,
+    assembly_id: Optional[str] = None,
+    altloc: str = "first",
+    include_discont_poly_poly_bonds: bool = True,
+) -> tuple[dict[str, Any], AtomArray, bool]:
+    """
+    Parse a PDB/mmCIF structure into Protenix JSON plus the normalized AtomArray.
+    """
+    input_file = Path(input_file)
+    if sample_name is None:
+        sample_name = sanitize_sample_name(input_file.stem)
+
+    if input_file.suffix.lower() == ".pdb":
+        with tempfile.NamedTemporaryFile(suffix=".cif") as tmp:
+            pdb_to_cif(str(input_file), tmp.name, entry_id=sample_name)
+            return cif_to_score_input_json(
+                tmp.name,
+                sample_name=sample_name,
+                assembly_id=assembly_id,
+                altloc=altloc,
+                include_discont_poly_poly_bonds=include_discont_poly_poly_bonds,
+            )
+    if input_file.suffix.lower() == ".cif":
+        return cif_to_score_input_json(
+            input_file,
+            sample_name=sample_name,
+            assembly_id=assembly_id,
+            altloc=altloc,
+            include_discont_poly_poly_bonds=include_discont_poly_poly_bonds,
+        )
+    raise RuntimeError(f"unsupported structure format: {input_file}")
+
+
+def cif_to_score_input_json(
+    mmcif_file: str | os.PathLike[str],
+    sample_name: str,
+    assembly_id: Optional[str] = None,
+    altloc: str = "first",
+    include_discont_poly_poly_bonds: bool = True,
+) -> tuple[dict[str, Any], AtomArray, bool]:
+    """
+    Convert mmCIF to scoring JSON while keeping the source AtomArray in sync.
+    """
+    parser = MMCIFParser(str(mmcif_file))
+    atom_array = parser.get_structure(altloc, model=1, bond_lenth_threshold=None)
+    if atom_array is None:
+        raise RuntimeError(f"failed to parse atom_site records from {mmcif_file}")
+
+    atom_array = Filter.remove_water(atom_array)
+    atom_array = Filter.remove_hydrogens(atom_array)
+    atom_array = parser.mse_to_met(atom_array)
+    atom_array = Filter.remove_element_X(atom_array)
+
+    if any("DIFFRACTION" in method for method in parser.methods):
+        atom_array = Filter.remove_crystallization_aids(
+            atom_array, parser.entity_poly_type
+        )
+
+    if assembly_id is not None:
+        atom_array = parser.expand_assembly(atom_array, assembly_id)
+
+    input_json = atom_array_to_input_json(
+        atom_array=atom_array,
+        parser=parser,
+        assembly_id=assembly_id,
+        output_json=None,
+        sample_name=sample_name,
+        save_entity_and_asym_id=True,
+        include_discont_poly_poly_bonds=include_discont_poly_poly_bonds,
+    )
+    chain_ids_preserved = copy_label_asym_ids_to_entity_ids(input_json)
+    atom_array = _filter_atom_array_to_json_entities(atom_array, input_json)
+    return input_json, atom_array, chain_ids_preserved
+
+
+def build_chain_id_map(
+    source_atom_array: AtomArray,
+    internal_atom_array: AtomArray,
+    prefer_identity: bool = True,
+) -> dict[str, Any]:
+    """
+    Map featurized chain IDs back to chain IDs in the parsed source AtomArray.
+    """
+    source_order = _chain_order(source_atom_array)
+    internal_order = _chain_order(internal_atom_array)
+    if len(source_order) != len(internal_order):
+        raise RuntimeError(
+            "source and featurized structures have different chain counts: "
+            f"{len(source_order)} vs {len(internal_order)}"
+        )
+    if len(set(source_order)) != len(source_order):
+        raise RuntimeError(f"duplicate source chain IDs: {source_order}")
+    if len(set(internal_order)) != len(internal_order):
+        raise RuntimeError(f"duplicate internal chain IDs: {internal_order}")
+
+    if prefer_identity and set(source_order) == set(internal_order):
+        internal_to_source = {chain_id: chain_id for chain_id in internal_order}
+        source_to_internal = {chain_id: chain_id for chain_id in source_order}
+    else:
+        internal_to_source = dict(zip(internal_order, source_order))
+        source_to_internal = dict(zip(source_order, internal_order))
+
+    return {
+        "source_chain_order": source_order,
+        "internal_chain_order": internal_order,
+        "internal_to_source": internal_to_source,
+        "source_to_internal": source_to_internal,
+    }
+
+
+def build_source_coord_map(
+    source_atom_array: AtomArray,
+) -> dict[tuple[str, int, str], np.ndarray]:
+    """
+    Build a coordinate lookup keyed by normalized chain, residue ID, and atom name.
+    """
+    source_coord_map: dict[tuple[str, int, str], np.ndarray] = {}
+    is_resolved = (
+        np.asarray(source_atom_array.is_resolved, dtype=bool)
+        if hasattr(source_atom_array, "is_resolved")
+        else np.ones(len(source_atom_array), dtype=bool)
+    )
+    for idx in range(len(source_atom_array)):
+        if not is_resolved[idx]:
+            continue
+        key = atom_lookup_key(source_atom_array, idx)
+        if key in source_coord_map:
+            raise RuntimeError(
+                "duplicate atom key while building score coordinate map: "
+                f"{key}. Select a single model/altloc before scoring."
+            )
+        source_coord_map[key] = np.asarray(
+            source_atom_array.coord[idx], dtype=np.float32
+        )
+    return source_coord_map
+
+
+def atom_lookup_key(atom_array: AtomArray, idx: int) -> tuple[str, int, str]:
+    """
+    Return the normalized coordinate lookup key for one atom.
+    """
+    return (
+        str(atom_array.chain_id[idx]),
+        int(atom_array.res_id[idx]),
+        str(atom_array.atom_name[idx]).strip(),
+    )
+
+
+def map_source_coords_to_internal(
+    source_coord_map: dict[tuple[str, int, str], np.ndarray],
+    internal_atom_array: AtomArray,
+    chain_id_map: dict[str, Any],
+    missing_atom_policy: str = "error",
+) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    """
+    Reorder source coordinates into the featurized AtomArray atom order.
+    """
+    if missing_atom_policy not in MISSING_ATOM_POLICIES:
+        raise ValueError(
+            f"missing_atom_policy must be one of {sorted(MISSING_ATOM_POLICIES)}, "
+            f"got {missing_atom_policy}"
+        )
+
+    internal_to_source = chain_id_map["internal_to_source"]
+    coords = np.zeros((len(internal_atom_array), 3), dtype=np.float32)
+    missing_atoms = []
+    for idx in range(len(internal_atom_array)):
+        internal_chain_id = str(internal_atom_array.chain_id[idx])
+        source_chain_id = internal_to_source.get(internal_chain_id, internal_chain_id)
+        source_key = (
+            source_chain_id,
+            int(internal_atom_array.res_id[idx]),
+            str(internal_atom_array.atom_name[idx]).strip(),
+        )
+        if source_key in source_coord_map:
+            coords[idx] = source_coord_map[source_key]
+            continue
+
+        missing_atoms.append(
+            {
+                "internal_chain_id": internal_chain_id,
+                "source_chain_id": source_chain_id,
+                "res_id": int(internal_atom_array.res_id[idx]),
+                "res_name": str(internal_atom_array.res_name[idx]).strip(),
+                "atom_name": str(internal_atom_array.atom_name[idx]).strip(),
+            }
+        )
+        if missing_atom_policy == "reference":
+            coords[idx] = np.asarray(internal_atom_array.coord[idx], dtype=np.float32)
+        elif missing_atom_policy == "zero":
+            coords[idx] = 0.0
+
+    if missing_atoms and missing_atom_policy == "error":
+        preview = ", ".join(
+            f"{atom['source_chain_id']}:{atom['res_id']}:{atom['atom_name']}"
+            for atom in missing_atoms[:5]
+        )
+        raise RuntimeError(
+            f"{len(missing_atoms)} featurized atoms are missing source coordinates. "
+            f"First missing atoms: {preview}. Use missing_atom_policy='reference' "
+            "or 'zero' only when fallback coordinates are acceptable."
+        )
+
+    return coords, missing_atoms
+
+
+def _filter_atom_array_to_json_entities(
+    atom_array: AtomArray,
+    input_json: dict[str, Any],
+) -> AtomArray:
+    label_entity_ids = {
+        str(entity["label_entity_id"])
+        for _, entity in iter_entity_dicts(input_json)
+        if "label_entity_id" in entity
+    }
+    if not label_entity_ids:
+        return atom_array
+    return atom_array[np.isin(atom_array.label_entity_id, list(label_entity_ids))]
+
+
+def _chain_order(atom_array: AtomArray) -> list[str]:
+    chain_starts = get_chain_starts(atom_array, add_exclusive_stop=False)
+    return [str(atom_array.chain_id[idx]) for idx in chain_starts]

--- a/protenix/model/protenix.py
+++ b/protenix/model/protenix.py
@@ -467,6 +467,33 @@ class Protenix(nn.Module):
         # For token counts larger than the largest threshold, use smallest chunk_size
         return 32  # extreme case for very large proteins
 
+    def _normalize_score_coordinates(
+        self,
+        score_coordinates: torch.Tensor,
+        input_feature_dict: dict[str, Any],
+    ) -> torch.Tensor:
+        """
+        Normalize externally supplied coordinates for confidence-only scoring.
+        """
+        if score_coordinates.ndim == 2:
+            score_coordinates = score_coordinates.unsqueeze(0)
+        if score_coordinates.ndim != 3 or score_coordinates.shape[-1] != 3:
+            raise ValueError(
+                "score_coordinates must have shape [N_atom, 3] or "
+                f"[N_sample, N_atom, 3], got {tuple(score_coordinates.shape)}"
+            )
+
+        expected_n_atom = input_feature_dict["atom_to_token_idx"].shape[-1]
+        if score_coordinates.shape[-2] != expected_n_atom:
+            raise ValueError(
+                "score_coordinates atom dimension does not match the featurized "
+                f"structure: got {score_coordinates.shape[-2]}, expected {expected_n_atom}"
+            )
+        return score_coordinates.to(
+            device=input_feature_dict["ref_pos"].device,
+            dtype=input_feature_dict["ref_pos"].dtype,
+        )
+
     def _main_inference_loop(
         self,
         input_feature_dict: dict[str, Any],
@@ -477,6 +504,7 @@ class Protenix(nn.Module):
         chunk_size: Optional[int] = 4,
         symmetric_permutation: SymmetricPermutation = None,
         mc_dropout: bool = False,
+        score_coordinates: Optional[torch.Tensor] = None,
     ) -> tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]:
         """
         Main inference loop (single model seed) for the Alphafold3 model.
@@ -526,56 +554,65 @@ class Protenix(nn.Module):
         time_tracker.update({"pairformer": step_trunk - step_st})
         # Sample diffusion
         # [..., N_sample, N_atom, 3]
-        N_sample = self.configs.sample_diffusion["N_sample"]
-        N_step = self.configs.sample_diffusion["N_step"]
+        if score_coordinates is None:
+            N_sample = self.configs.sample_diffusion["N_sample"]
+            N_step = self.configs.sample_diffusion["N_step"]
 
-        noise_schedule = self.inference_noise_scheduler(
-            N_step=N_step, device=s_inputs.device, dtype=s_inputs.dtype
-        )
-        cache = dict()
-        if self.enable_diffusion_shared_vars_cache:
-            # line 1-5 of algorithm 21 calculate z in diffusion conditioning
-            cache["pair_z"] = autocasting_disable_decorator(
-                self.configs.skip_amp.sample_diffusion
-            )(self.diffusion_module.diffusion_conditioning.prepare_cache)(
-                input_feature_dict["relp"], z, False
+            noise_schedule = self.inference_noise_scheduler(
+                N_step=N_step, device=s_inputs.device, dtype=s_inputs.dtype
             )
-            cache["p_lm/c_l"] = autocasting_disable_decorator(
-                self.configs.skip_amp.sample_diffusion
-            )(self.diffusion_module.atom_attention_encoder.prepare_cache)(
-                ref_pos=input_feature_dict["ref_pos"],
-                ref_charge=input_feature_dict["ref_charge"],
-                ref_mask=input_feature_dict["ref_mask"],
-                ref_element=input_feature_dict["ref_element"],
-                ref_atom_name_chars=input_feature_dict["ref_atom_name_chars"],
-                atom_to_token_idx=input_feature_dict["atom_to_token_idx"],
-                d_lm=input_feature_dict["d_lm"],
-                v_lm=input_feature_dict["v_lm"],
-                pad_info=input_feature_dict["pad_info"],
-                r_l=True,
-                z=cache["pair_z"],
-                inplace_safe=False,
+            cache = dict()
+            if self.enable_diffusion_shared_vars_cache:
+                # line 1-5 of algorithm 21 calculate z in diffusion conditioning
+                cache["pair_z"] = autocasting_disable_decorator(
+                    self.configs.skip_amp.sample_diffusion
+                )(self.diffusion_module.diffusion_conditioning.prepare_cache)(
+                    input_feature_dict["relp"], z, False
+                )
+                cache["p_lm/c_l"] = autocasting_disable_decorator(
+                    self.configs.skip_amp.sample_diffusion
+                )(self.diffusion_module.atom_attention_encoder.prepare_cache)(
+                    ref_pos=input_feature_dict["ref_pos"],
+                    ref_charge=input_feature_dict["ref_charge"],
+                    ref_mask=input_feature_dict["ref_mask"],
+                    ref_element=input_feature_dict["ref_element"],
+                    ref_atom_name_chars=input_feature_dict["ref_atom_name_chars"],
+                    atom_to_token_idx=input_feature_dict["atom_to_token_idx"],
+                    d_lm=input_feature_dict["d_lm"],
+                    v_lm=input_feature_dict["v_lm"],
+                    pad_info=input_feature_dict["pad_info"],
+                    r_l=True,
+                    z=cache["pair_z"],
+                    inplace_safe=False,
+                )
+            else:
+                cache["pair_z"] = None
+                cache["p_lm/c_l"] = [None, None]
+            pred_dict["coordinate"] = self.sample_diffusion(
+                denoise_net=self.diffusion_module,
+                input_feature_dict=input_feature_dict,
+                s_inputs=s_inputs,
+                s_trunk=s,
+                z_trunk=None if cache["pair_z"] is not None else z,
+                pair_z=cache["pair_z"],
+                p_lm=cache["p_lm/c_l"][0],
+                c_l=cache["p_lm/c_l"][1],
+                N_sample=N_sample,
+                noise_schedule=noise_schedule,
+                inplace_safe=inplace_safe,
+                enable_efficient_fusion=self.enable_efficient_fusion,
             )
         else:
-            cache["pair_z"] = None
-            cache["p_lm/c_l"] = [None, None]
-        pred_dict["coordinate"] = self.sample_diffusion(
-            denoise_net=self.diffusion_module,
-            input_feature_dict=input_feature_dict,
-            s_inputs=s_inputs,
-            s_trunk=s,
-            z_trunk=None if cache["pair_z"] is not None else z,
-            pair_z=cache["pair_z"],
-            p_lm=cache["p_lm/c_l"][0],
-            c_l=cache["p_lm/c_l"][1],
-            N_sample=N_sample,
-            noise_schedule=noise_schedule,
-            inplace_safe=inplace_safe,
-            enable_efficient_fusion=self.enable_efficient_fusion,
-        )
+            pred_dict["coordinate"] = self._normalize_score_coordinates(
+                score_coordinates=score_coordinates,
+                input_feature_dict=input_feature_dict,
+            )
 
         step_diffusion = time.time()
-        time_tracker.update({"diffusion": step_diffusion - step_trunk})
+        diffusion_time = (
+            0.0 if score_coordinates is not None else step_diffusion - step_trunk
+        )
+        time_tracker.update({"diffusion": diffusion_time})
         # Distogram logits: log contact_probs only, to reduce the dimension
         pred_dict["contact_probs"] = autocasting_disable_decorator(True)(
             sample_confidence.compute_contact_prob
@@ -857,6 +894,7 @@ class Protenix(nn.Module):
         symmetric_permutation: SymmetricPermutation = None,
         disable_inplace: bool = False,
         mc_dropout_apply_rate: float = 0.4,
+        score_coordinates: Optional[torch.Tensor] = None,
     ) -> tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]:
         """
         Forward pass of the Alphafold3 model.
@@ -868,6 +906,8 @@ class Protenix(nn.Module):
             mode (str): Mode of operation ('train', 'inference', 'eval'). Defaults to 'inference'.
             current_step (Optional[int]): Current training step. Defaults to None.
             symmetric_permutation (SymmetricPermutation): Symmetric permutation object. Defaults to None.
+            score_coordinates (Optional[torch.Tensor]): Fixed coordinates to score in
+                inference mode, with shape [N_atom, 3] or [N_sample, N_atom, 3].
 
         Returns:
             tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, Any]]:
@@ -875,6 +915,8 @@ class Protenix(nn.Module):
         """
 
         assert mode in ["train", "eval", "inference"]
+        if score_coordinates is not None and mode != "inference":
+            raise ValueError("score_coordinates is only supported in inference mode")
         not_use_gradient = not (self.training or torch.is_grad_enabled())
         inplace_safe = not_use_gradient and (not disable_inplace)
 
@@ -901,17 +943,30 @@ class Protenix(nn.Module):
             )
             log_dict["N_cycle"] = N_cycle
         elif mode == "inference":
-            pred_dict, log_dict, time_tracker = self.main_inference_loop(
-                input_feature_dict=input_feature_dict,
-                label_dict=None,
-                N_cycle=self.N_cycle,
-                mode=mode,
-                inplace_safe=inplace_safe,
-                chunk_size=self.configs.infer_setting.chunk_size,
-                N_model_seed=self.N_model_seed,
-                symmetric_permutation=None,
-                mc_dropout_apply_rate=mc_dropout_apply_rate,
-            )
+            if score_coordinates is None:
+                pred_dict, log_dict, time_tracker = self.main_inference_loop(
+                    input_feature_dict=input_feature_dict,
+                    label_dict=None,
+                    N_cycle=self.N_cycle,
+                    mode=mode,
+                    inplace_safe=inplace_safe,
+                    chunk_size=self.configs.infer_setting.chunk_size,
+                    N_model_seed=self.N_model_seed,
+                    symmetric_permutation=None,
+                    mc_dropout_apply_rate=mc_dropout_apply_rate,
+                )
+            else:
+                pred_dict, log_dict, time_tracker = self._main_inference_loop(
+                    input_feature_dict=input_feature_dict,
+                    label_dict=None,
+                    N_cycle=self.N_cycle,
+                    mode=mode,
+                    inplace_safe=inplace_safe,
+                    chunk_size=self.configs.infer_setting.chunk_size,
+                    symmetric_permutation=None,
+                    mc_dropout=False,
+                    score_coordinates=score_coordinates,
+                )
             log_dict.update({"time": time_tracker})
         elif mode == "eval":
             if label_dict is not None:

--- a/runner/batch_inference.py
+++ b/runner/batch_inference.py
@@ -959,6 +959,302 @@ def predict(
     "--input",
     type=str,
     required=True,
+    help="Input PDB/CIF file or directory to score.",
+)
+@click.option("-o", "--out_dir", default="./output", type=str, help="Output directory.")
+@click.option(
+    "--recursive",
+    is_flag=True,
+    default=False,
+    help="Recursively search input directories for PDB/CIF files.",
+)
+@click.option(
+    "--glob",
+    type=str,
+    default="*.pdb,*.cif",
+    help="Comma-separated filename globs to include when input is a directory.",
+)
+@click.option(
+    "--sample_name",
+    type=str,
+    default=None,
+    help="Override sample name when scoring a single structure.",
+)
+@click.option(
+    "--missing_atom_policy",
+    type=click.Choice(["error", "reference", "zero"]),
+    default="error",
+    help="How to handle atoms expected by Protenix but absent from the source file.",
+)
+@click.option(
+    "--write_full_confidence",
+    is_flag=True,
+    default=False,
+    help="Write per-atom and per-token confidence JSON.",
+)
+@click.option(
+    "--write_scored_cif",
+    is_flag=True,
+    default=False,
+    help="Write scored.cif with source coordinates and confidence B-factors.",
+)
+@click.option("-c", "--cycle", type=int, default=10, help="Pairformer cycle number.")
+@click.option("-d", "--dtype", type=str, default="bf16", help="Inference dtype.")
+@click.option(
+    "-n",
+    "--model_name",
+    type=str,
+    default="protenix_base_default_v1.0.0",
+    help="Model checkpoint name.",
+)
+@click.option("--use_msa", type=bool, default=True, help="Whether to use protein MSA.")
+@click.option(
+    "--use_template",
+    type=bool,
+    default=False,
+    help="Use templates during input preprocessing.",
+)
+@click.option(
+    "--use_rna_msa",
+    type=bool,
+    default=False,
+    help="Use RNA MSA during input preprocessing.",
+)
+@click.option(
+    "--trimul_kernel",
+    type=str,
+    default="cuequivariance",
+    help="Triangle multiplicative update kernel ('cuequivariance' or 'torch').",
+)
+@click.option(
+    "--triatt_kernel",
+    type=str,
+    default="cuequivariance",
+    help=(
+        "Triangle attention kernel ('triattention', 'cuequivariance', "
+        "'deepspeed', or 'torch')."
+    ),
+)
+@click.option(
+    "--enable_cache",
+    type=bool,
+    default=True,
+    help="Cache shareable variables in the diffusion module.",
+)
+@click.option(
+    "--enable_fusion",
+    type=bool,
+    default=True,
+    help="Enable efficient kernel fusion in the diffusion transformer.",
+)
+@click.option(
+    "--enable_tf32",
+    type=bool,
+    default=True,
+    help="Enable TF32 for FP32 matrix multiplications.",
+)
+@click.option(
+    "--msa_server_mode",
+    type=str,
+    default="protenix",
+    help="MSA search mode ('protenix' or 'colabfold').",
+)
+@click.option(
+    "--altloc",
+    default="first",
+    type=str,
+    help=(
+        "Select the first altloc conformation of each residue, "
+        "or specify the altloc letter ('A', 'B', etc.)."
+    ),
+)
+@click.option(
+    "--assembly_id",
+    default=None,
+    type=str,
+    help="Assembly ID for structure extension (default: no extension).",
+)
+@click.option(
+    "--include_discont_poly_poly_bonds",
+    type=bool,
+    default=True,
+    help="Whether to include discontinuous polymer-polymer bonds.",
+)
+@click.option(
+    "--kalign_binary_path",
+    type=str,
+    default=None,
+    help="Path to kalign (searches in PATH if not provided).",
+)
+@click.option(
+    "--hmmsearch_binary_path",
+    type=str,
+    default=None,
+    help="Path to hmmsearch (searches in PATH if not provided).",
+)
+@click.option(
+    "--hmmbuild_binary_path",
+    type=str,
+    default=None,
+    help="Path to hmmbuild (searches in PATH if not provided).",
+)
+@click.option(
+    "--seqres_database_path",
+    type=str,
+    default=None,
+    help="Path to the sequence database for template search.",
+)
+@click.option(
+    "--nhmmer_binary_path",
+    type=str,
+    default=None,
+    help="Path to nhmmer for RNA MSA search.",
+)
+@click.option(
+    "--hmmalign_binary_path",
+    type=str,
+    default=None,
+    help="Path to hmmalign for RNA MSA search.",
+)
+@click.option(
+    "--hmmbuild_rna_binary_path",
+    type=str,
+    default=None,
+    help="Path to RNA-specific hmmbuild.",
+)
+@click.option(
+    "--ntrna_database_path",
+    type=str,
+    default=None,
+    help="Path to the NT-RNA database.",
+)
+@click.option(
+    "--rfam_database_path",
+    type=str,
+    default=None,
+    help="Path to the Rfam database.",
+)
+@click.option(
+    "--rna_central_database_path",
+    type=str,
+    default=None,
+    help="Path to the RNAcentral database.",
+)
+@click.option(
+    "--nhmmer_n_cpu",
+    type=int,
+    default=None,
+    help="Number of CPUs for nhmmer.",
+)
+def score(
+    input: str,
+    out_dir: str,
+    recursive: bool,
+    glob: str,
+    sample_name: Optional[str],
+    missing_atom_policy: str,
+    write_full_confidence: bool,
+    write_scored_cif: bool,
+    cycle: int,
+    dtype: str,
+    model_name: str,
+    use_msa: bool,
+    use_template: bool,
+    use_rna_msa: bool,
+    trimul_kernel: str,
+    triatt_kernel: str,
+    enable_cache: bool,
+    enable_fusion: bool,
+    enable_tf32: bool,
+    msa_server_mode: str,
+    altloc: str,
+    assembly_id: Optional[str],
+    include_discont_poly_poly_bonds: bool,
+    kalign_binary_path: Optional[str],
+    hmmsearch_binary_path: Optional[str],
+    hmmbuild_binary_path: Optional[str],
+    seqres_database_path: Optional[str],
+    nhmmer_binary_path: Optional[str],
+    hmmalign_binary_path: Optional[str],
+    hmmbuild_rna_binary_path: Optional[str],
+    ntrna_database_path: Optional[str],
+    rfam_database_path: Optional[str],
+    rna_central_database_path: Optional[str],
+    nhmmer_n_cpu: Optional[int],
+) -> None:
+    """
+    Score existing structures with the Protenix confidence head.
+    """
+    init_logging()
+    logger.info(f"Run score with input={input}, out_dir={out_dir}")
+    if not os.path.exists(input):
+        raise RuntimeError(f"input path {input} does not exist")
+    assert trimul_kernel in [
+        "cuequivariance",
+        "torch",
+    ], "Invalid trimul_kernel. Options: 'cuequivariance', 'torch'."
+    assert triatt_kernel in [
+        "triattention",
+        "cuequivariance",
+        "deepspeed",
+        "torch",
+    ], (
+        "Invalid triatt_kernel. Options: 'triattention', "
+        "'cuequivariance', 'deepspeed', 'torch'."
+    )
+
+    from runner.scoring import score_structures
+
+    result = score_structures(
+        input_path=input,
+        out_dir=out_dir,
+        recursive=recursive,
+        glob=glob,
+        sample_name=sample_name,
+        missing_atom_policy=missing_atom_policy,
+        write_full_confidence=write_full_confidence,
+        write_scored_cif=write_scored_cif,
+        assembly_id=assembly_id,
+        altloc=altloc,
+        include_discont_poly_poly_bonds=include_discont_poly_poly_bonds,
+        use_msa=use_msa,
+        use_template=use_template,
+        use_rna_msa=use_rna_msa,
+        msa_server_mode=msa_server_mode,
+        hmmsearch_binary_path=hmmsearch_binary_path,
+        hmmbuild_binary_path=hmmbuild_binary_path,
+        seqres_database_path=seqres_database_path,
+        nhmmer_binary_path=nhmmer_binary_path,
+        hmmalign_binary_path=hmmalign_binary_path,
+        hmmbuild_rna_binary_path=hmmbuild_rna_binary_path,
+        ntrna_database_path=ntrna_database_path,
+        rfam_database_path=rfam_database_path,
+        rna_central_database_path=rna_central_database_path,
+        nhmmer_n_cpu=nhmmer_n_cpu,
+        cycle=cycle,
+        dtype=dtype,
+        model_name=model_name,
+        trimul_kernel=trimul_kernel,
+        triatt_kernel=triatt_kernel,
+        enable_cache=enable_cache,
+        enable_fusion=enable_fusion,
+        enable_tf32=enable_tf32,
+        kalign_binary_path=kalign_binary_path,
+    )
+    logger.info(
+        "Score-only job completed: %s succeeded, %s failed. Results saved to %s",
+        result["succeeded"],
+        result["failed"],
+        result["out_dir"],
+    )
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "-i",
+    "--input",
+    type=str,
+    required=True,
     help="PDB/CIF files or directory to generate inference JSONs.",
 )
 @click.option("-o", "--out_dir", type=str, default="./output", help="Output directory.")
@@ -1350,6 +1646,7 @@ def inputprep(
 
 
 protenix_cli.add_command(predict, name="pred")
+protenix_cli.add_command(score, name="score")
 protenix_cli.add_command(tojson, name="json")
 protenix_cli.add_command(msa, name="msa")
 protenix_cli.add_command(msatemplate, name="mt")

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -235,6 +235,49 @@ class InferenceRunner(object):
 
         return prediction
 
+    @torch.no_grad()
+    def score(
+        self,
+        data: Mapping[str, Mapping[str, Any]],
+        coordinates: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """
+        Score externally supplied coordinates with the trunk and confidence heads.
+
+        Args:
+            data (Mapping[str, Mapping[str, Any]]): Input data dictionary.
+            coordinates (torch.Tensor): Atom coordinates in featurized atom order,
+                with shape [N_atom, 3] or [N_sample, N_atom, 3].
+
+        Returns:
+            dict[str, torch.Tensor]: Confidence prediction results.
+        """
+        eval_precision = {
+            "fp32": torch.float32,
+            "bf16": torch.bfloat16,
+            "fp16": torch.float16,
+        }[self.configs.dtype]
+
+        enable_amp = (
+            torch.autocast(device_type="cuda", dtype=eval_precision)
+            if torch.cuda.is_available()
+            else nullcontext()
+        )
+
+        data = to_device(data, self.device)
+        coordinates = coordinates.to(self.device)
+        with enable_amp:
+            prediction, _, _ = self.model(
+                input_feature_dict=data["input_feature_dict"],
+                label_full_dict=None,
+                label_dict=None,
+                mode="inference",
+                mc_dropout_apply_rate=0.0,
+                score_coordinates=coordinates,
+            )
+
+        return prediction
+
     def print(self, msg: str) -> None:
         """
         Print message only on the master rank (rank 0).

--- a/runner/scoring.py
+++ b/runner/scoring.py
@@ -1,0 +1,363 @@
+# Copyright 2024 ByteDance and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import csv
+import json
+import logging
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import torch
+
+from protenix.data.inference.infer_dataloader import InferenceDataset
+from protenix.data.inference.structure_scoring import (
+    build_chain_id_map,
+    build_source_coord_map,
+    collect_structure_files,
+    map_source_coords_to_internal,
+    sanitize_sample_name,
+    structure_to_score_input_json,
+)
+from protenix.data.utils import save_structure_cif
+from protenix.utils.file_io import save_json
+from protenix.utils.torch_utils import round_values
+from runner.dumper import get_clean_full_confidence
+from runner.inference import update_inference_configs
+
+logger = logging.getLogger(__name__)
+
+
+def score_structures(
+    input_path: str,
+    out_dir: str = "./output",
+    recursive: bool = False,
+    glob: str = "*.pdb,*.cif",
+    sample_name: Optional[str] = None,
+    missing_atom_policy: str = "error",
+    write_full_confidence: bool = False,
+    write_scored_cif: bool = False,
+    assembly_id: Optional[str] = None,
+    altloc: str = "first",
+    include_discont_poly_poly_bonds: bool = True,
+    use_msa: bool = True,
+    use_template: bool = False,
+    use_rna_msa: bool = False,
+    msa_server_mode: str = "protenix",
+    hmmsearch_binary_path: Optional[str] = None,
+    hmmbuild_binary_path: Optional[str] = None,
+    seqres_database_path: Optional[str] = None,
+    nhmmer_binary_path: Optional[str] = None,
+    hmmalign_binary_path: Optional[str] = None,
+    hmmbuild_rna_binary_path: Optional[str] = None,
+    ntrna_database_path: Optional[str] = None,
+    rfam_database_path: Optional[str] = None,
+    rna_central_database_path: Optional[str] = None,
+    nhmmer_n_cpu: Optional[int] = None,
+    cycle: int = 10,
+    dtype: str = "bf16",
+    model_name: str = "protenix_base_default_v1.0.0",
+    trimul_kernel: str = "cuequivariance",
+    triatt_kernel: str = "cuequivariance",
+    enable_cache: bool = True,
+    enable_fusion: bool = True,
+    enable_tf32: bool = True,
+    kalign_binary_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Score PDB/mmCIF structures without running diffusion sampling.
+    """
+    from runner.batch_inference import get_default_runner, preprocess_input
+
+    out_dir_path = Path(out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
+
+    globs = [pattern.strip() for pattern in glob.split(",") if pattern.strip()]
+    structure_files = collect_structure_files(
+        input_path=input_path,
+        recursive=recursive,
+        globs=globs,
+    )
+    if not structure_files:
+        raise RuntimeError(
+            f"can not read a valid `pdb` or `cif` file from {input_path}"
+        )
+    if sample_name is not None and len(structure_files) > 1:
+        raise RuntimeError("--sample_name can only be used when scoring one structure")
+
+    runner = get_default_runner(
+        seeds=[101],
+        n_cycle=cycle,
+        n_step=1,
+        n_sample=1,
+        dtype=dtype,
+        model_name=model_name,
+        use_msa=use_msa,
+        trimul_kernel=trimul_kernel,
+        triatt_kernel=triatt_kernel,
+        enable_cache=enable_cache,
+        enable_fusion=enable_fusion,
+        enable_tf32=enable_tf32,
+        use_template=use_template,
+        use_rna_msa=use_rna_msa,
+        need_atom_confidence=write_full_confidence,
+        kalign_binary_path=kalign_binary_path,
+    )
+
+    rows: list[dict[str, Any]] = []
+    failed_records: list[str] = []
+    seen_names: set[str] = set()
+    with tempfile.TemporaryDirectory(prefix="protenix-score-") as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        for structure_file in structure_files:
+            base_name = sample_name or sanitize_sample_name(structure_file.stem)
+            current_sample_name = _unique_sample_name(base_name, seen_names)
+            sample_out_dir = out_dir_path / current_sample_name
+            sample_out_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                logger.info("Scoring %s as %s", structure_file, current_sample_name)
+                input_json, source_atom_array, chain_ids_preserved = (
+                    structure_to_score_input_json(
+                        input_file=structure_file,
+                        sample_name=current_sample_name,
+                        assembly_id=assembly_id,
+                        altloc=altloc,
+                        include_discont_poly_poly_bonds=include_discont_poly_poly_bonds,
+                    )
+                )
+                intermediate_json = tmp_dir_path / f"{current_sample_name}.json"
+                with open(intermediate_json, "w") as f:
+                    json.dump([input_json], f, indent=4)
+
+                processed_json = preprocess_input(
+                    input_json=str(intermediate_json),
+                    out_dir=str(sample_out_dir),
+                    use_msa=use_msa,
+                    use_template=use_template,
+                    use_rna_msa=use_rna_msa,
+                    msa_server_mode=msa_server_mode,
+                    hmmsearch_binary_path=hmmsearch_binary_path,
+                    hmmbuild_binary_path=hmmbuild_binary_path,
+                    seqres_database_path=seqres_database_path,
+                    nhmmer_binary_path=nhmmer_binary_path,
+                    hmmalign_binary_path=hmmalign_binary_path,
+                    hmmbuild_rna_binary_path=hmmbuild_rna_binary_path,
+                    ntrna_database_path=ntrna_database_path,
+                    rfam_database_path=rfam_database_path,
+                    rna_central_database_path=rna_central_database_path,
+                    nhmmer_n_cpu=nhmmer_n_cpu,
+                )
+
+                runner.configs.input_json_path = processed_json
+                runner.configs.dump_dir = str(out_dir_path)
+                dataset = InferenceDataset(runner.configs)
+                data, internal_atom_array, data_error_message = dataset[0]
+                if data_error_message:
+                    raise RuntimeError(data_error_message)
+
+                new_configs = update_inference_configs(
+                    runner.configs,
+                    data["N_token"].item(),
+                )
+                runner.update_model_configs(new_configs)
+
+                chain_id_map = build_chain_id_map(
+                    source_atom_array=source_atom_array,
+                    internal_atom_array=internal_atom_array,
+                    prefer_identity=chain_ids_preserved,
+                )
+                chain_id_map["source_chain_ids_preserved_in_json"] = chain_ids_preserved
+                source_coord_map = build_source_coord_map(source_atom_array)
+                score_coordinates, missing_atoms = map_source_coords_to_internal(
+                    source_coord_map=source_coord_map,
+                    internal_atom_array=internal_atom_array,
+                    chain_id_map=chain_id_map,
+                    missing_atom_policy=missing_atom_policy,
+                )
+
+                prediction = runner.score(
+                    data=data,
+                    coordinates=torch.from_numpy(score_coordinates),
+                )
+                _save_score_outputs(
+                    prediction=prediction,
+                    sample_out_dir=sample_out_dir,
+                    sample_name=current_sample_name,
+                    atom_array=internal_atom_array,
+                    entity_poly_type=data["entity_poly_type"],
+                    chain_id_map=chain_id_map,
+                    missing_atoms=missing_atoms,
+                    write_full_confidence=write_full_confidence,
+                    write_scored_cif=write_scored_cif,
+                )
+                rows.append(
+                    _summary_row(
+                        sample_name=current_sample_name,
+                        input_path=structure_file,
+                        summary_confidence=prediction["summary_confidence"][0],
+                    )
+                )
+                logger.info("Score-only run succeeded for %s", current_sample_name)
+            except Exception as exc:
+                error_message = f"{structure_file}\t{type(exc).__name__}: {exc}"
+                failed_records.append(error_message)
+                with open(sample_out_dir / "error.txt", "w", encoding="utf-8") as f:
+                    f.write(f"{error_message}\n{traceback.format_exc()}")
+                logger.error(
+                    "Score-only run failed for %s: %s",
+                    structure_file,
+                    traceback.format_exc(),
+                )
+            finally:
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+    _write_summary_csv(rows=rows, output_path=out_dir_path / "summary.csv")
+    if failed_records:
+        with open(out_dir_path / "failed_records.txt", "w", encoding="utf-8") as f:
+            f.write("\n".join(failed_records) + "\n")
+    if not rows and failed_records:
+        raise RuntimeError(
+            f"all {len(failed_records)} score-only jobs failed; "
+            f"see {out_dir_path / 'failed_records.txt'}"
+        )
+    return {
+        "succeeded": len(rows),
+        "failed": len(failed_records),
+        "out_dir": str(out_dir_path),
+    }
+
+
+def _save_score_outputs(
+    prediction: dict[str, Any],
+    sample_out_dir: Path,
+    sample_name: str,
+    atom_array: Any,
+    entity_poly_type: dict[str, str],
+    chain_id_map: dict[str, Any],
+    missing_atoms: list[dict[str, Any]],
+    write_full_confidence: bool,
+    write_scored_cif: bool,
+) -> None:
+    save_json(
+        _jsonable(round_values(copy.deepcopy(prediction["summary_confidence"][0]))),
+        sample_out_dir / "summary_confidence.json",
+        indent=4,
+    )
+    save_json(
+        chain_id_map,
+        sample_out_dir / "chain_id_map.json",
+        indent=4,
+    )
+    if missing_atoms:
+        save_json(
+            {"missing_atoms": missing_atoms},
+            sample_out_dir / "missing_atoms.json",
+            indent=4,
+        )
+    if write_full_confidence:
+        save_json(
+            get_clean_full_confidence(copy.deepcopy(prediction["full_data"][0])),
+            sample_out_dir / "full_confidence.json",
+            indent=None,
+        )
+    if write_scored_cif:
+        b_factor = _atom_plddt_b_factor(prediction["full_data"][0])
+        if b_factor is not None:
+            atom_array.set_annotation("b_factor", b_factor)
+        save_structure_cif(
+            atom_array=atom_array,
+            pred_coordinate=prediction["coordinate"][0],
+            output_fpath=str(sample_out_dir / "scored.cif"),
+            entity_poly_type={
+                k: v for k, v in entity_poly_type.items() if v != "non-polymer"
+            },
+            pdb_id=sample_name,
+        )
+
+
+def _atom_plddt_b_factor(full_data: dict[str, Any]) -> Optional[np.ndarray]:
+    atom_plddt = full_data.get("atom_plddt")
+    if atom_plddt is None:
+        return None
+    if isinstance(atom_plddt, torch.Tensor):
+        if atom_plddt.dtype == torch.bfloat16:
+            atom_plddt = atom_plddt.float()
+        atom_plddt = atom_plddt.detach().cpu().numpy()
+    return np.round(np.asarray(atom_plddt, dtype=np.float32) * 100.0, 2)
+
+
+def _summary_row(
+    sample_name: str,
+    input_path: Path,
+    summary_confidence: dict[str, Any],
+) -> dict[str, Any]:
+    summary = _jsonable(round_values(copy.deepcopy(summary_confidence)))
+    row = {
+        "name": sample_name,
+        "input_path": str(input_path),
+    }
+    row.update(
+        {
+            key: value if _is_csv_scalar(value) else json.dumps(value)
+            for key, value in summary.items()
+        }
+    )
+    return row
+
+
+def _write_summary_csv(rows: list[dict[str, Any]], output_path: Path) -> None:
+    if not rows:
+        return
+    fieldnames = ["name", "input_path"]
+    fieldnames.extend(
+        sorted({key for row in rows for key in row.keys()} - set(fieldnames))
+    )
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        if value.dtype == torch.bfloat16:
+            value = value.float()
+        value = value.detach().cpu().numpy()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _jsonable(v) for key, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    return value
+
+
+def _is_csv_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _unique_sample_name(name: str, seen_names: set[str]) -> str:
+    candidate = name
+    suffix = 2
+    while candidate in seen_names:
+        candidate = f"{name}_{suffix}"
+        suffix += 1
+    seen_names.add(candidate)
+    return candidate

--- a/tests/test_structure_scoring.py
+++ b/tests/test_structure_scoring.py
@@ -1,0 +1,193 @@
+# Copyright 2024 ByteDance and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+from biotite.structure import AtomArray
+
+from protenix.data.inference.structure_scoring import (
+    build_chain_id_map,
+    build_source_coord_map,
+    collect_structure_files,
+    copy_label_asym_ids_to_entity_ids,
+    map_source_coords_to_internal,
+)
+
+
+def _atom_array(chain_ids, res_ids, atom_names, res_names, coords):
+    atom_array = AtomArray(len(chain_ids))
+    atom_array.chain_id = np.array(chain_ids)
+    atom_array.res_id = np.array(res_ids)
+    atom_array.atom_name = np.array(atom_names)
+    atom_array.res_name = np.array(res_names)
+    atom_array.coord = np.asarray(coords, dtype=np.float32)
+    return atom_array
+
+
+class TestStructureScoring(unittest.TestCase):
+    def test_copy_label_asym_ids_to_entity_ids(self):
+        input_json = {
+            "sequences": [
+                {
+                    "proteinChain": {
+                        "sequence": "AA",
+                        "count": 2,
+                        "label_asym_id": ["A", "B"],
+                    }
+                },
+                {"ligand": {"ligand": "CCD_ATP", "count": 1, "label_asym_id": ["C"]}},
+            ],
+            "name": "sample",
+        }
+
+        self.assertTrue(copy_label_asym_ids_to_entity_ids(input_json))
+        self.assertEqual(input_json["sequences"][0]["proteinChain"]["id"], ["A", "B"])
+        self.assertEqual(input_json["sequences"][1]["ligand"]["id"], ["C"])
+
+    def test_copy_label_asym_ids_rejects_duplicates(self):
+        input_json = {
+            "sequences": [
+                {
+                    "proteinChain": {
+                        "sequence": "AA",
+                        "count": 2,
+                        "label_asym_id": ["A", "A"],
+                    }
+                },
+            ],
+            "name": "sample",
+        }
+
+        self.assertFalse(copy_label_asym_ids_to_entity_ids(input_json))
+        self.assertNotIn("id", input_json["sequences"][0]["proteinChain"])
+
+    def test_collect_structure_files_filters_supported_suffixes(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "a.pdb").write_text("", encoding="utf-8")
+            (root / "b.cif").write_text("", encoding="utf-8")
+            (root / "ignore.txt").write_text("", encoding="utf-8")
+            nested = root / "nested"
+            nested.mkdir()
+            (nested / "c.pdb").write_text("", encoding="utf-8")
+
+            files = collect_structure_files(root)
+            self.assertEqual([path.name for path in files], ["a.pdb", "b.cif"])
+
+            recursive_files = collect_structure_files(root, recursive=True)
+            self.assertEqual(
+                [path.name for path in recursive_files],
+                ["a.pdb", "b.cif", "c.pdb"],
+            )
+
+    def test_build_chain_id_map_prefers_identity_over_order(self):
+        source = _atom_array(
+            chain_ids=["B", "A"],
+            res_ids=[1, 1],
+            atom_names=["N", "N"],
+            res_names=["GLY", "ALA"],
+            coords=[[2, 0, 0], [1, 0, 0]],
+        )
+        internal = _atom_array(
+            chain_ids=["A", "B"],
+            res_ids=[1, 1],
+            atom_names=["N", "N"],
+            res_names=["ALA", "GLY"],
+            coords=[[1, 0, 0], [2, 0, 0]],
+        )
+
+        chain_id_map = build_chain_id_map(source, internal)
+
+        self.assertEqual(chain_id_map["internal_to_source"], {"A": "A", "B": "B"})
+
+    def test_build_chain_id_map_can_fall_back_to_order(self):
+        source = _atom_array(
+            chain_ids=["B", "A"],
+            res_ids=[1, 1],
+            atom_names=["N", "N"],
+            res_names=["GLY", "ALA"],
+            coords=[[2, 0, 0], [1, 0, 0]],
+        )
+        internal = _atom_array(
+            chain_ids=["A", "B"],
+            res_ids=[1, 1],
+            atom_names=["N", "N"],
+            res_names=["ALA", "GLY"],
+            coords=[[1, 0, 0], [2, 0, 0]],
+        )
+
+        chain_id_map = build_chain_id_map(source, internal, prefer_identity=False)
+
+        self.assertEqual(chain_id_map["internal_to_source"], {"A": "B", "B": "A"})
+
+    def test_map_source_coords_to_internal_with_reference_fallback(self):
+        source = _atom_array(
+            chain_ids=["A", "A", "B"],
+            res_ids=[1, 1, 1],
+            atom_names=["N", "CA", "C1"],
+            res_names=["ALA", "ALA", "ATP"],
+            coords=[[1, 0, 0], [2, 0, 0], [3, 0, 0]],
+        )
+        internal = _atom_array(
+            chain_ids=["X", "X", "Y", "Y"],
+            res_ids=[1, 1, 1, 1],
+            atom_names=["N", "CA", "C1", "O1"],
+            res_names=["ALA", "ALA", "ATP", "ATP"],
+            coords=[[9, 0, 0], [9, 1, 0], [9, 2, 0], [9, 3, 0]],
+        )
+        chain_id_map = build_chain_id_map(source, internal)
+        coords, missing_atoms = map_source_coords_to_internal(
+            source_coord_map=build_source_coord_map(source),
+            internal_atom_array=internal,
+            chain_id_map=chain_id_map,
+            missing_atom_policy="reference",
+        )
+
+        self.assertEqual(len(missing_atoms), 1)
+        self.assertTrue(np.allclose(coords[0], [1, 0, 0]))
+        self.assertTrue(np.allclose(coords[1], [2, 0, 0]))
+        self.assertTrue(np.allclose(coords[2], [3, 0, 0]))
+        self.assertTrue(np.allclose(coords[3], [9, 3, 0]))
+
+    def test_map_source_coords_to_internal_errors_on_missing_atoms(self):
+        source = _atom_array(
+            chain_ids=["A"],
+            res_ids=[1],
+            atom_names=["N"],
+            res_names=["ALA"],
+            coords=[[1, 0, 0]],
+        )
+        internal = _atom_array(
+            chain_ids=["A", "A"],
+            res_ids=[1, 1],
+            atom_names=["N", "CA"],
+            res_names=["ALA", "ALA"],
+            coords=[[1, 0, 0], [2, 0, 0]],
+        )
+        chain_id_map = build_chain_id_map(source, internal)
+
+        with self.assertRaises(RuntimeError):
+            map_source_coords_to_internal(
+                source_coord_map=build_source_coord_map(source),
+                internal_atom_array=internal,
+                chain_id_map=chain_id_map,
+                missing_atom_policy="error",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a native score-only workflow for Protenix so users can evaluate existing PDB/mmCIF coordinates with the model trunk and confidence heads without running diffusion sampling.

This addresses bytedance/Protenix#227.

## Motivation

Issue #227 asks whether Protenix can be used in a scoring-only mode, especially for complexes. The existing inference path always samples new coordinates through diffusion, while the confidence head already accepts predicted coordinates. This PR exposes that capability through a narrow, native workflow instead of requiring users to rely on a pinned external fork.

## Changes

- Adds fixed-coordinate inference support in `Protenix.forward()` and `_main_inference_loop()` via `score_coordinates`.
- Adds `InferenceRunner.score()` to run the trunk, distogram, confidence head, and existing confidence summary code on supplied atom coordinates.
- Adds `protenix score` CLI support for PDB/mmCIF inputs and directories.
- Adds structure parsing and coordinate remapping utilities that:
  - preserve source chain IDs when possible through generated JSON `id` fields,
  - map source coordinates into Protenix featurized atom order,
  - detect duplicate atom keys and missing atoms,
  - support configurable missing-atom fallback policies.
- Writes score outputs:
  - `summary.csv`,
  - `<sample>/summary_confidence.json`,
  - `<sample>/chain_id_map.json`,
  - optional `<sample>/full_confidence.json`,
  - optional `<sample>/scored.cif`,
  - failure records when applicable.
- Documents `protenix score` in the README and training/inference instructions.
- Adds focused unit tests for structure file collection, chain ID preservation, chain mapping, and coordinate remapping.

## Design Notes

The implementation deliberately keeps the first version small:

- It reuses the existing inference preprocessing path for MSA, template, and RNA MSA handling.
- It reuses the existing confidence summary implementation instead of adding separate scoring metrics.
- It skips diffusion only when fixed coordinates are explicitly provided.
- It does not add role-aware MSA caches, target/binder-specific outputs, ipSAE-style metrics, or multi-model scoring in this PR.

## Validation

Ran:

```bash
git diff --cached --check
uvx ruff check protenix/model/protenix.py runner/inference.py protenix/data/inference/structure_scoring.py runner/scoring.py runner/batch_inference.py tests/test_structure_scoring.py
python3 -m py_compile protenix/model/protenix.py runner/inference.py protenix/data/inference/structure_scoring.py runner/scoring.py runner/batch_inference.py tests/test_structure_scoring.py
uv run --python 3.11 ... python -m pytest tests/test_structure_scoring.py
```

Results:

- Ruff passed.
- Python compilation passed.
- `tests/test_structure_scoring.py` passed: 7 tests.
- Verified the Click group exposes `score --help` with `LAYERNORM_TYPE=torch`.

## Local Environment Notes

I did not run a full model-backed `protenix score` on an example structure locally because this machine is missing the Protenix CCD runtime data file at `/Users/vuductai/common/components.cif`, which blocks the repo's normal parser path. On this macOS host, CLI import smoke also requires `LAYERNORM_TYPE=torch` to avoid the existing CUDA fused-layernorm compile path.
