### PR TITLE
Log a concise warning instead of a full traceback when MSA search falls back

### DIFF
--- a/protenix/web_service/colab_request_parser.py
+++ b/protenix/web_service/colab_request_parser.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import os
 import subprocess
-import traceback
 from collections import defaultdict
 from copy import deepcopy
 from os.path import exists as opexists, join as opjoin
@@ -273,8 +272,7 @@ class RequestParser(object):
                     server_mode=mode,
                 )
             except Exception as e:
-                error_message = f"MMSEQS2 failed with the following error message:\n{traceback.format_exc()}"
-                print(error_message)
+                print(f"WARNING: MMseqs2 MSA search failed ({type(e).__name__}: {e}); continuing without this search.")
 
         elif mode == "colabfold":
             res_dirs = []
@@ -298,8 +296,7 @@ class RequestParser(object):
                     )
                     res_dirs.append(res_dir)
                 except Exception as e:
-                    error_message = f"MMSEQS2 failed with the following error message:\n{traceback.format_exc()}"
-                    print(error_message)
+                    print(f"WARNING: MMseqs2 MSA search failed ({type(e).__name__}: {e}); continuing without this search.")
             if len(fasta_dict) > 1:
                 # search paired MSA
                 try:
@@ -318,8 +315,7 @@ class RequestParser(object):
                         server_mode=mode,
                     )
                 except Exception as e:
-                    error_message = f"MMSEQS2 failed with the following error message:\n{traceback.format_exc()}"
-                    print(error_message)
+                    print(f"WARNING: MMseqs2 MSA search failed ({type(e).__name__}: {e}); continuing without this search.")
             else:
                 pairing_msa_fpath = os.path.join(
                     msa_res_dir,


### PR DESCRIPTION
When the MMseqs2 MSA server returns an error, the three fallback handlers in `protenix/web_service/colab_request_parser.py` catch the exception and then `print(f"MMSEQS2 failed with the following error message:\n{traceback.format_exc()}")`.

The exception is **handled** — the pipeline continues (e.g. using the query sequence as its own MSA), so nothing has actually crashed. But dumping a full `Traceback (most recent call last): ...` to stderr makes this routine, recoverable event look like a fatal error. It is easy to misread as a crash, and it trips up log/CI scanners that flag on the string `Traceback`.

This PR replaces the full-traceback print in all three handlers with a single concise line, e.g.:

```
WARNING: MMseqs2 MSA search failed (Exception: MMseqs2 API is giving errors ...); continuing without this search.
```

and drops the now-unused `import traceback`.

- No behavioral change beyond log verbosity — the fallback path is unchanged.
- The exception type and message are still surfaced, just without the misleading full stack trace.
- Consistent with the file’s existing `print`-based logging style (no new logging dependency).