### PR TITLE
model: fall back to torch layer norm on sm_120

### DIFF
--- a/protenix/model/triangular/layers.py
+++ b/protenix/model/triangular/layers.py
@@ -30,7 +30,21 @@ from protenix.model.utils import (
     permute_final_dims,
 )
 
-fastln_is_installed = os.getenv("LAYERNORM_TYPE", "fast_layernorm") == "fast_layernorm"
+
+def _use_fast_layer_norm() -> bool:
+    configured_type = os.getenv("LAYERNORM_TYPE")
+    if configured_type is not None:
+        return configured_type == "fast_layernorm"
+
+    # The custom kernel can produce non-finite outputs on sm_120. Prefer the
+    # native implementation there unless the user explicitly opts in.
+    if torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 0):
+        return False
+
+    return True
+
+
+fastln_is_installed = _use_fast_layer_norm()
 if fastln_is_installed:
     from protenix.model.layer_norm.layer_norm import FusedLayerNorm
 

--- a/runner/inference.py
+++ b/runner/inference.py
@@ -27,7 +27,6 @@ import torch
 import torch.distributed as dist
 from biotite.structure import AtomArray
 
-
 from configs.configs_base import configs as configs_base
 from configs.configs_data import data_configs
 from configs.configs_inference import inference_configs
@@ -121,8 +120,9 @@ class InferenceRunner(object):
                 "is first called."
             )
 
-        use_fastlayernorm = os.getenv("LAYERNORM_TYPE", "fast_layernorm")
-        if use_fastlayernorm == "fast_layernorm":
+        from protenix.model.triangular.layers import fastln_is_installed
+
+        if fastln_is_installed:
             logging.info(
                 "Kernels will be compiled when fast_layernorm is first called."
             )
@@ -591,7 +591,7 @@ def infer_predict(runner: InferenceRunner, configs: Any) -> None:
                 new_configs = update_inference_configs(configs, data["N_token"].item())
                 runner.update_model_configs(new_configs)
                 prediction = runner.predict(data)
-                
+
                 # Regularize the C-terminal carboxyl oxygens (O / OXT) of each
                 # polymer chain: the O<->OXT substructure-permutation symmetry can
                 # leave one oxygen under-constrained and drift far away. Rebuild
@@ -600,7 +600,7 @@ def infer_predict(runner: InferenceRunner, configs: Any) -> None:
                 prediction["coordinate"] = fix_cterminal_carboxyl_oxygens(
                     prediction["coordinate"], atom_array
                 )
-                
+
                 runner.dumper.dump(
                     dataset_name="",
                     pdb_id=sample_name,

--- a/tests/test_layer_norm_selection.py
+++ b/tests/test_layer_norm_selection.py
@@ -1,0 +1,62 @@
+# Copyright 2024 ByteDance and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+_previous_layer_norm_type = os.environ.get("LAYERNORM_TYPE")
+os.environ["LAYERNORM_TYPE"] = "torch"
+
+from protenix.model.triangular.layers import _use_fast_layer_norm
+
+if _previous_layer_norm_type is None:
+    del os.environ["LAYERNORM_TYPE"]
+else:
+    os.environ["LAYERNORM_TYPE"] = _previous_layer_norm_type
+
+
+class TestLayerNormSelection(unittest.TestCase):
+    def test_falls_back_to_torch_on_sm120(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(12, 0)),
+        ):
+            self.assertFalse(_use_fast_layer_norm())
+
+    def test_keeps_fast_layer_norm_on_other_cuda_architectures(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        ):
+            self.assertTrue(_use_fast_layer_norm())
+
+    def test_explicit_fast_layer_norm_overrides_sm120_fallback(self) -> None:
+        with (
+            patch.dict(os.environ, {"LAYERNORM_TYPE": "fast_layernorm"}, clear=True),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(12, 0)),
+        ):
+            self.assertTrue(_use_fast_layer_norm())
+
+    def test_explicit_torch_layer_norm_is_preserved(self) -> None:
+        with patch.dict(os.environ, {"LAYERNORM_TYPE": "torch"}, clear=True):
+            self.assertFalse(_use_fast_layer_norm())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use the native PyTorch LayerNorm by default on CUDA sm_120 devices
- preserve the existing fast LayerNorm default on other architectures
- preserve explicit `LAYERNORM_TYPE` overrides, including an explicit opt-in to `fast_layernorm`
- make inference logging reflect the implementation that was actually selected

## Background

The latest reproducer in #186 uses Protenix 2.0.0 on an RTX 5090 with the triangle kernels already set to `torch`, but the log shows that `fast_layernorm` remains enabled before the run produces a CIF without valid coordinates. The CIF writer only copies `prediction["coordinate"]` into the output AtomArray, so it cannot recover once model inference has produced non-finite coordinates.

This matches the Blackwell evidence in #265 and merged PR #257: affected sm_120 users reported non-finite coordinates/confidence, while `LAYERNORM_TYPE="torch"` allowed inference to finish with valid structures. The fallback is therefore limited to sm_120 and remains overridable, avoiding a default change for architectures where the custom kernel is established.

This PR addresses the Protenix 2.0.0 Blackwell variant reported in #186. It does not claim to resolve the older, separate >5,000-residue A100 reports in that thread.

Related to #186 and #265.

## Validation

- `python -m unittest tests.test_layer_norm_selection tests.test_condition_transition tests.test_attention_pair_bias -v` (7 tests passed)
- `pre-commit run --files protenix/model/triangular/layers.py runner/inference.py tests/test_layer_norm_selection.py` (all hooks passed)
- RTX 5070 Ti (sm_120), driver 596.36, PyTorch 2.12.0.dev20260408+cu128: automatic selection used `OpenFoldLayerNorm` and produced finite bf16 output for an `[8, 121, 64]` tensor

A full model inference was not run locally because the clean audit checkout did not contain the model checkpoint or Protenix data cache, and the available environments did not have the CUDA compiler required to build the custom extension.