### PR TITLE
web_service: fix viewer modification schema

### DIFF
--- a/protenix/web_service/viewer.py
+++ b/protenix/web_service/viewer.py
@@ -139,15 +139,21 @@ class DnaRnaProteinEntityWidget(widgets.VBox):
         result[recode_name]["count"] = self.copies_int_text.value
         result[recode_name]["sequence"] = sequence
         assert len(result[recode_name]["sequence"]) > 0, "sequence length must > 0"
+        if sequence_type == "Protein":
+            modification_type_key = "ptmType"
+            modification_position_key = "ptmPosition"
+        else:
+            modification_type_key = "modificationType"
+            modification_position_key = "basePosition"
         result[recode_name]["modifications"] = [
             {
-                "modificationType": item.children[0].value,
-                "Position": item.children[1].value,
+                modification_type_key: item.children[0].value,
+                modification_position_key: item.children[1].value,
             }
             for item in self.modifications
         ]
         for item in result[recode_name]["modifications"]:
-            pos = item["Position"]
+            pos = item[modification_position_key]
             assert pos <= len(result[recode_name]["sequence"]), "position out of range"
 
         if sequence_type == "Protein":

--- a/tests/test_web_service_viewer.py
+++ b/tests/test_web_service_viewer.py
@@ -1,0 +1,40 @@
+import unittest
+
+from protenix.web_service.viewer import DnaRnaProteinEntityWidget
+
+
+class TestDnaRnaProteinEntityWidget(unittest.TestCase):
+    def _get_modification(self, molecule_type):
+        widget = DnaRnaProteinEntityWidget()
+        widget.molecule_type_dropdown.value = molecule_type
+        widget.sequence_text.value = "A"
+        widget.add_modification_callback(None)
+
+        entity_key = {
+            "Protein": "proteinChain",
+            "DNA": "dnaSequence",
+            "RNA": "rnaSequence",
+        }[molecule_type]
+        return widget.get_result()[entity_key]["modifications"][0]
+
+    def test_protein_modification_uses_inference_schema_keys(self):
+        self.assertEqual(
+            self._get_modification("Protein"),
+            {"ptmType": "CCD_XXX", "ptmPosition": 1},
+        )
+
+    def test_dna_modification_uses_inference_schema_keys(self):
+        self.assertEqual(
+            self._get_modification("DNA"),
+            {"modificationType": "CCD_XXX", "basePosition": 1},
+        )
+
+    def test_rna_modification_uses_inference_schema_keys(self):
+        self.assertEqual(
+            self._get_modification("RNA"),
+            {"modificationType": "CCD_XXX", "basePosition": 1},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- serialize protein viewer modifications with `ptmType` and `ptmPosition`
- serialize DNA/RNA viewer modifications with `modificationType` and `basePosition`
- validate positions through the selected schema key
- add focused regression tests for Protein, DNA, and RNA entities

## Root cause

The viewer used the generic keys `modificationType` and `Position` for every polymer type, while the inference JSON parser expects type-specific modification keys. Requests created by the viewer therefore failed during featurization whenever they contained a modification.

## Testing

- `python -m pytest tests/test_web_service_viewer.py -q` (3 passed)
- `python -m flake8 protenix/web_service/viewer.py tests/test_web_service_viewer.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0 errors)

Closes #335