### PR TITLE
web_service: fix covalent position validation

### DIFF
--- a/protenix/web_service/viewer.py
+++ b/protenix/web_service/viewer.py
@@ -600,16 +600,13 @@ class ProtenixInputViewer(widgets.VBox):
             assert len(covalent_bond["left_atom"]) != 0, "left atom is empty"
             assert len(covalent_bond["right_atom"]) != 0, "right_atom atom is empty"
 
-            left_entiy = result["sequences"][covalent_bond["left_entity"] - 1]
-            left_entiy_seq = left_entiy[[item for item in left_entiy.keys()][0]]
-            right_entity = result["sequences"][covalent_bond["right_entity"] - 1]
-            right_entity_seq = right_entity[[item for item in right_entity.keys()][0]]
-            assert (
-                covalent_bond["left_position"] <= len(left_entiy_seq)
-                and covalent_bond["left_position"] >= 1
-            ), "left position out of range"
-            assert (
-                covalent_bond["right_position"] <= len(right_entity_seq)
-                and covalent_bond["right_position"] >= 1
-            ), "right position out of range"
+            for side in ["left", "right"]:
+                entity = result["sequences"][covalent_bond[f"{side}_entity"] - 1]
+                entity_info = next(iter(entity.values()))
+                position = covalent_bond[f"{side}_position"]
+                assert position >= 1, f"{side} position out of range"
+                if "sequence" in entity_info:
+                    assert position <= len(
+                        entity_info["sequence"]
+                    ), f"{side} position out of range"
         return result

--- a/tests/test_web_service_covalent_bonds.py
+++ b/tests/test_web_service_covalent_bonds.py
@@ -1,0 +1,47 @@
+import unittest
+
+from protenix.web_service.viewer import ProtenixInputViewer
+
+
+class TestProtenixInputViewerCovalentBonds(unittest.TestCase):
+    def test_polymer_position_uses_sequence_length(self):
+        viewer = ProtenixInputViewer()
+        viewer.name.value = "demo"
+
+        viewer.add_dna_rna_protein_callback(None)
+        protein = viewer.dna_rna_protein_entities[0].children[0]
+        protein.sequence_text.value = "AAAAA"
+
+        viewer.add_ligand_smiles_callback(None)
+        ligand = viewer.ligand_smiles_entities[0].children[0]
+        ligand.smiles_text.value = "C"
+
+        viewer.covalent_bonds.on_add_convalent_bond(None)
+        bond = viewer.covalent_bonds.convalent_bonds[0]
+        bond.children[1].value = 5
+        bond.children[2].value = "CA"
+        bond.children[3].value = 2
+        bond.children[4].value = 1
+        bond.children[5].value = "C1"
+
+        self.assertEqual(
+            viewer.get_result()["covalent_bonds"],
+            [
+                {
+                    "left_entity": 1,
+                    "left_position": 5,
+                    "left_atom": "CA",
+                    "right_entity": 2,
+                    "right_position": 1,
+                    "right_atom": "C1",
+                }
+            ],
+        )
+
+        bond.children[1].value = 6
+        with self.assertRaisesRegex(AssertionError, "left position out of range"):
+            viewer.get_result()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate polymer covalent-bond positions against the actual sequence length
- keep the existing positive-position check for every entity type
- defer non-polymer upper-bound validation to the inference parser, which has parsed ligand residue and atom information
- add a focused viewer regression test for a terminal protein residue bonded to a ligand

## Root cause

`ProtenixInputViewer.get_result()` unwrapped each entity to its inner metadata dictionary and used `len()` on that dictionary. A polymer dictionary normally contains three fields, so valid sequence positions greater than 3 were rejected before featurization.

## Testing

- `python -m pytest tests/test_web_service_covalent_bonds.py -q` (1 passed)
- `python -m unittest tests.test_web_service_covalent_bonds -v` (1 passed)
- `python -m py_compile protenix/web_service/viewer.py tests/test_web_service_covalent_bonds.py`
- `python -m flake8 protenix/web_service/viewer.py tests/test_web_service_covalent_bonds.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0 errors)

Closes #341