### PR TITLE
template: reject invalid negative JSON indices

### DIFF
--- a/protenix/data/template/template_utils.py
+++ b/protenix/data/template/template_utils.py
@@ -881,6 +881,13 @@ class TemplateHitFeaturizer:
                 errors.append(f"Invalid template info at index {idx}")
                 continue
                 
+            if any(q_idx < 0 for q_idx in q_indices):
+                errors.append(f"Invalid queryIndices at index {idx}: negative index")
+                continue
+            if any(t_idx < -1 for t_idx in t_indices):
+                errors.append(f"Invalid templateIndices at index {idx}: index below -1")
+                continue
+
             mapping = {q: t for q, t in zip(q_indices, t_indices)}
             
             try:

--- a/tests/test_json_template_indices.py
+++ b/tests/test_json_template_indices.py
@@ -1,0 +1,83 @@
+# Copyright 2024 ByteDance and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import json
+
+import numpy as np
+import pytest
+from protenix.data.template.template_utils import TemplateHitFeaturizer
+
+
+@pytest.fixture(scope="module")
+def json_template_input():
+    with open("examples/example_with_json_template/demo_ab.json") as f:
+        query_sequence = json.load(f)[0]["sequences"][0]["proteinChain"]["sequence"]
+    with open("examples/example_with_json_template/h_seq.json") as f:
+        template = json.load(f)[0]
+    return query_sequence, template
+
+
+@pytest.fixture
+def featurizer():
+    return TemplateHitFeaturizer(
+        mmcif_dir="/tmp/dummy_mmcif_dir",
+        template_cache_dir=None,
+        kalign_binary_path=None,
+        _zero_center_positions=True,
+    )
+
+
+def _parse_mapping(featurizer, json_template_input, query_idx, template_idx):
+    query_sequence, source_template = json_template_input
+    template = copy.deepcopy(source_template)
+    template["queryIndices"] = [query_idx]
+    template["templateIndices"] = [template_idx]
+    return featurizer.parse_json_templates([template], query_sequence)
+
+
+def test_json_template_rejects_negative_query_index(featurizer, json_template_input):
+    result = _parse_mapping(featurizer, json_template_input, -1, 0)
+
+    assert result.errors == ["Invalid queryIndices at index 0: negative index"]
+    assert result.features == []
+    assert result.hits == []
+
+
+def test_json_template_rejects_template_index_below_gap(
+    featurizer, json_template_input
+):
+    result = _parse_mapping(featurizer, json_template_input, 0, -2)
+
+    assert result.errors == ["Invalid templateIndices at index 0: index below -1"]
+    assert result.features == []
+    assert result.hits == []
+
+
+def test_json_template_accepts_gap_index(featurizer, json_template_input):
+    result = _parse_mapping(featurizer, json_template_input, 0, -1)
+
+    assert result.errors == []
+    assert np.sum(result.features[0]["template_all_atom_masks"][0]) == 0
+    assert result.features[0]["template_sequence"][:1] == b"-"
+    assert result.hits[0].indices_hit[0] == -1
+
+
+def test_json_template_preserves_normal_mapping(featurizer, json_template_input):
+    result = _parse_mapping(featurizer, json_template_input, 0, 0)
+
+    assert result.errors == []
+    assert np.sum(result.features[0]["template_all_atom_masks"][0]) > 0
+    assert result.features[0]["template_sequence"][:1] == b"Q"
+    assert result.hits[0].indices_hit[0] == 0


### PR DESCRIPTION
## Summary

- reject negative JSON-template query indices before applying a mapping
- reject template indices below the supported `-1` gap sentinel
- preserve legal gap entries and normal residue mappings
- add focused tests using the repository's real embedded mmCIF example

## Root cause

`parse_json_templates` checked only `q_idx < num_query` and `t_idx < len(all_pos)`. Python and NumPy therefore interpreted malformed negative indices as offsets from the end: query `-1` wrote to the final query residue, while template `-2` read the second-to-last template residue. Both cases returned no parser errors and produced valid-looking template features.

The new lower-bound checks run before parsing or applying the mapping. `templateIndices == -1` remains the existing gap sentinel. This does not change public APIs or valid JSON-template behavior.

Fixes #342.

## Validation

- `python -m pytest tests/test_json_template_indices.py tests/test_json_template_parser.py -q` (`5 passed`)
- the new regression file against unmodified `main` (`2 failed, 2 passed`; both malformed-negative cases were accepted)
- local template utility tests: `python -m pytest tests/test_fetch_remote_cif.py::TestFetchOrReadCifLocal tests/test_fetch_remote_cif.py::TestTemplateHitProcessorInit -q` (`5 passed`)
- `python -m compileall -q protenix/data/template/template_utils.py tests/test_json_template_indices.py`
- pre-commit `check-ast`, `check-merge-conflict`, `check-added-large-files`, and `pydoclint` hooks passed
- CI-fatal flake8 selection (`E9,F63,F7,F82`) passed with zero findings
- `ufmt check tests/test_json_template_indices.py` passed
- `git diff --check upstream/main...HEAD`

A full pre-commit run is not reported as passing because the existing `template_utils.py` has pre-existing W293 blank-line and whole-file ufmt differences. Those unrelated formatting changes are intentionally excluded from this focused diff.

The tests ran in an isolated Windows environment with Python 3.13.13, PyTorch 2.12.0.dev20260408+cu128, Biopython 1.85, Biotite 1.4.0, modelcif 1.4, gemmi 0.6.7, pdbeccdutils 1.0.0, and RDKit 2025.09.3.