### PR TITLE
triangular: add optional fast_trimul fp16 triangle multiply backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ pip install --upgrade protenix --index-url https://pypi.org/simple
 
 If your package mirror lags behind the latest GitHub release, use the official PyPI index above to make sure the installed CLI matches the commands shown in this README.
 
+Optional: install the [`fast_trimul`](https://github.com/tiagomonteiro0715/fast_trimul) fp16 CuTe triangle-multiply backend (inference-only; enable with `triangle_multiplicative: "fast_trimul"`, see [docs/kernels.md](docs/kernels.md)):
+
+```bash
+pip install "protenix[fast_trimul]"
+```
+
 ### 🧬 Quick Prediction
 
 ```bash

--- a/configs/configs_base.py
+++ b/configs/configs_base.py
@@ -126,7 +126,7 @@ model_configs = {
     ),  # NOTE: Number of blocks in each activation checkpoint, if None, no checkpointing is performed.
     "hidden_scale_up": False,  # whether to scale up hidden dim in pairformer and confidence head
     # switch of kernels
-    "triangle_multiplicative": "cuequivariance",  # cuequivariance, torch
+    "triangle_multiplicative": "cuequivariance",  # cuequivariance, torch, fast_trimul
     "triangle_attention": "cuequivariance",  # triattention, cuequivariance, deepspeed, torch
     "enable_diffusion_shared_vars_cache": False,
     "enable_efficient_fusion": False,

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -38,9 +38,9 @@
 
 - **Triangle_multiplicative Kernel Options**
     
-    The Triangle Multiplicative operation supports two implementations, configurable in [configs_base.py](../configs/configs_base.py):
+    The Triangle Multiplicative operation supports three implementations, configurable in [configs_base.py](../configs/configs_base.py):
     ```python
-    triangle_multiplicative = "cuequivariance"  # or "torch"
+    triangle_multiplicative = "cuequivariance"  # or "torch" / "fast_trimul"
     ```
 
     1. cuEquivariance Kernel (Default)
@@ -48,4 +48,14 @@
 
     2. Torch Native
     Standard PyTorch implementation.
+
+    3. fast_trimul (optional, third-party)
+    Fused fp16 [CuTe DSL](https://github.com/tiagomonteiro0715/fast_trimul) kernel. **Inference only** (its
+    backward is a correct but slow torch recompute), and it automatically falls back to the
+    torch path when unavailable or during training. Install with:
+    ```bash
+    pip install "protenix[fast_trimul]"   # brings in fast_trimul + cuda-python<13
+    ```
+    The fast path targets NVIDIA Ampere (sm80) with `N` divisible by 8; other
+    hardware/shapes/dtypes use fast_trimul's built-in pure-torch fallback.
 

--- a/protenix/model/triangular/triangular.py
+++ b/protenix/model/triangular/triangular.py
@@ -24,6 +24,13 @@ import torch.nn as nn
 from protenix.model.triangular.layers import Attention, LayerNorm, OpenfoldLinear
 from protenix.model.utils import chunk_layer, is_fp16_enabled, permute_final_dims
 
+try:
+    import fast_trimul
+
+    FAST_TRIMUL_AVAILABLE = True
+except ImportError:
+    FAST_TRIMUL_AVAILABLE = False
+
 
 def kernel_triangular_mult(
     x: torch.Tensor,
@@ -195,6 +202,19 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
         self.linear_b_g = OpenfoldLinear(
             self.c_z, self.c_hidden, bias=False, init="gating"
         )
+
+    def _ensure_fast_impl(self, z: torch.Tensor) -> None:
+        """Lazily build the fast_trimul module and load this layer's weights into
+        it once. Stored outside nn.Module registration (via __dict__) so it never
+        appears in state_dict / checkpoints."""
+        if self.__dict__.get("_fast_impl") is not None:
+            return
+        mode = "outgoing" if self._outgoing else "incoming"
+        impl = fast_trimul.FastTriangleMultiplication(
+            d_z=self.c_z, d_c=self.c_hidden, mode=mode, residual=False
+        ).to(z.device)
+        impl.load_weights(self.state_dict(), source="protenix")
+        self.__dict__["_fast_impl"] = impl
 
     def _inference_forward(
         self,
@@ -486,6 +506,18 @@ class TriangleMultiplicativeUpdate(BaseTriangleMultiplicativeUpdate):
             [*, N_res, N_res, C_z] output tensor
         """
         _input_inplace_safe = inplace_safe is True
+
+        # fast_trimul: optional third-party fp16 CuTe backend. Inference only --
+        # its backward is a correct but slow torch recompute and it holds a
+        # weight copy -- so we fall back to "torch" when unavailable or training.
+        if triangle_multiplicative == "fast_trimul":
+            if FAST_TRIMUL_AVAILABLE and not self.training:
+                self._ensure_fast_impl(z)
+                update = self._fast_impl(z, mask=mask)
+                if _input_inplace_safe and _add_with_inplace:
+                    return update + z
+                return update
+            triangle_multiplicative = "torch"
 
         # Note: cuequivariance requires that the hidden dimension c must equal c_z.
         # If this condition is not met, an AssertionError will be raised.

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,10 @@ setup(
         "protenix": ["model/layer_norm/kernel/*"],
     },
     install_requires=install_requires,
+    extras_require={
+        # Optional fp16 CuTe triangle-multiply backend (inference).
+        "fast_trimul": ["fast_trimul>=2.1.2", "cuda-python<13"],
+    },
     license="Apache 2.0 License",
     platforms="manylinux1",
     entry_points={


### PR DESCRIPTION
## Summary

Adds `"fast_trimul"` as a third option for the existing `triangle_multiplicative` kernel selector, alongside `"cuequivariance"` and `"torch"`. 

It routes the Triangle Multiplicative Update through `fast_trimul` (https://github.com/tiagomonteiro0715/fast_trimul), a fused fp16 CuTe DSL kernel, for inference. 

It reuses the selector Protenix already threads everywhere, so no new plumbing is added and the default behaviour is unchanged.

## Changes

- `protenix/model/triangular/triangular.py`
  - Guarded optional import (`FAST_TRIMUL_AVAILABLE`).
  - `TriangleMultiplicativeUpdate._ensure_fast_impl(...)`: lazily builds the fast_trimul module and loads this layer's weights into it once (Protenix's bias-free `OpenfoldLinear` weights map directly). Stored off the `nn.Module` registry (via `__dict__`) so it never appears in `state_dict` / checkpoints.
  - New branch at the top of `forward`: when `triangle_multiplicative == "fast_trimul"` and the package is available and the module is in eval mode, it runs the kernel and honours the existing residual/inplace contract (`update + z` when
    `_input_inplace_safe and _add_with_inplace`, else `update`). If unavailable or in training, it transparently falls back to the `"torch"` path (no error).
- `configs/configs_base.py`: extend the `triangle_multiplicative` comment to list `fast_trimul`.
- `setup.py`: add `extras_require={"fast_trimul": ["fast_trimul>=2.1.2", "cuda-python<13"]}`.
- `docs/kernels.md` and `README.md`: document the option, install (`pip install "protenix[fast_trimul]"`), and its limits.

## Testing

- Local: modified module imports and byte-compiles cleanly; with the selector left   at its default the existing paths are untouched.
- Existing suite: `pytest tests/`
- Correctness: fast_trimul is separately validated against reference TriMul outputs   (fp16 tolerance) in its own repo; setting `triangle_multiplicative: "fast_trimul"`  on an A100 produced
- Fast path is Ampere (sm80) + `N % 8 == 0` + fp16; other hardware/shapes/dtypes use
  fast_trimul's built-in pure-torch fallback.

## Notes

- Inference only by design (its backward is a correct but slow torch recompute, and it holds an fp16 weight copy), so it is gated to eval mode.
- The kernel is fp16 while Protenix commonly runs bf16; the fast path casts to fp16  and otherwise falls back to torch.
- No new required dependency. Everything is behind the optional extra and the existing selector.